### PR TITLE
Fix(as-you-code): watch tf files only

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import { CheckovInstallation, installOrUpdateCheckov } from './checkovInstaller'
 import { runCheckovScan } from './checkovRunner';
 import { applyDiagnostics } from './diagnostics';
 import { fixCodeActionProvider, providedCodeActionKinds } from './suggestFix';
-import { getLogger, saveCheckovResult } from './utils';
+import { getLogger, isSupportedFileType, saveCheckovResult } from './utils';
 import { initializeStatusBarItem, setErrorStatusBarItem, setPassedStatusBarItem, setReadyStatusBarItem, setSyncingStatusBarItem, showContactUsDetails } from './userInterface';
 import { assureTokenSet } from './token';
 import { INSTALL_OR_UPDATE_CHECKOV_COMMAND, OPEN_CONFIGURATION_COMMAND, OPEN_EXTERNAL_COMMAND, REMOVE_DIAGNOSTICS_COMMAND, RUN_FILE_SCAN_COMMAND } from './commands';
@@ -58,6 +58,8 @@ export function activate(context: vscode.ExtensionContext): void {
             resetCancelTokenSource();
             const token = assureTokenSet(logger, OPEN_CONFIGURATION_COMMAND);
             vscode.commands.executeCommand(REMOVE_DIAGNOSTICS_COMMAND);
+            if (!fileUri && vscode.window.activeTextEditor && !isSupportedFileType(vscode.window.activeTextEditor.document.fileName, true))
+                return;
             if (!!token && vscode.window.activeTextEditor) {
                 await runScan(vscode.window.activeTextEditor, token, checkovRunCancelTokenSource.token, fileUri);
             }
@@ -81,7 +83,7 @@ export function activate(context: vscode.ExtensionContext): void {
             if (!extensionReady) return;
             if ((vscode.window.activeTextEditor && 
                 changeEvent.document.uri.toString() !== vscode.window.activeTextEditor.document.uri.toString())
-                || !changeEvent.document.fileName.endsWith('.tf')) 
+                || !isSupportedFileType(changeEvent.document.fileName)) 
                 return;
             vscode.commands.executeCommand(REMOVE_DIAGNOSTICS_COMMAND);
             // Run scan on enter (new line)
@@ -102,14 +104,17 @@ export function activate(context: vscode.ExtensionContext): void {
         }),
         vscode.workspace.onDidSaveTextDocument(saveEvent => {
             if (!extensionReady) return;
-            if (vscode.window.activeTextEditor && saveEvent.uri.toString() !== vscode.window.activeTextEditor.document.uri.toString()) {
+            if ((vscode.window.activeTextEditor && saveEvent.uri.toString() !== vscode.window.activeTextEditor.document.uri.toString())
+                || !isSupportedFileType(saveEvent.fileName)) {
                 setReadyStatusBarItem();
                 return;
             }
             vscode.commands.executeCommand(RUN_FILE_SCAN_COMMAND);
         }),
         vscode.window.onDidChangeActiveTextEditor(changeViewEvent => {
-            if (!extensionReady) return;
+            if (!extensionReady || 
+                (changeViewEvent && !isSupportedFileType(changeViewEvent.document.fileName))) 
+                return;
             vscode.commands.executeCommand(RUN_FILE_SCAN_COMMAND);
         })
     );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,10 +79,11 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(
         vscode.workspace.onDidChangeTextDocument(changeEvent => {
             if (!extensionReady) return;
-            if (vscode.window.activeTextEditor && changeEvent.document.uri.toString() !== vscode.window.activeTextEditor.document.uri.toString()) 
+            if ((vscode.window.activeTextEditor && 
+                changeEvent.document.uri.toString() !== vscode.window.activeTextEditor.document.uri.toString())
+                || !changeEvent.document.fileName.endsWith('.tf')) 
                 return;
             vscode.commands.executeCommand(REMOVE_DIAGNOSTICS_COMMAND);
-        
             // Run scan on enter (new line)
             if (!changeEvent.contentChanges.some(change => change.text.includes('\n'))) return;
 

--- a/src/userInterface.ts
+++ b/src/userInterface.ts
@@ -26,6 +26,11 @@ ${logDirectoryPath}`;
         });
 };
 
+export const showUnsupportedFileMessage = (): void => {
+    const message = 'Unsupported file type for Checkov scanning, We support .tf files only.';
+    vscode.window.showWarningMessage(message);
+};
+
 export const statusBarItem: vscode.StatusBarItem = vscode.window.createStatusBarItem();
 
 export const initializeStatusBarItem = (onClickCommand: string): void  => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@ import winston = require('winston');
 import { FailedCheckovCheck } from './checkovRunner';
 import { DiagnosticReferenceCode } from './diagnostics';
 import { CHECKOV_MAP } from './extension';
+import { showUnsupportedFileMessage } from './userInterface';
 
 type ExecOutput = [stdout: string, stderr: string];
 export const asyncExec = async (commandToExecute: string) : Promise<ExecOutput> => {
@@ -13,7 +14,15 @@ export const asyncExec = async (commandToExecute: string) : Promise<ExecOutput> 
             resolve([stdout, stderr]);
         });
     });
-}; 
+};
+
+export const isSupportedFileType = (fileName: string, showMessage = false): boolean => {
+    if (!fileName.endsWith('.tf')) {
+        showMessage && showUnsupportedFileMessage();
+        return false;
+    }
+    return true;
+};
 
 export const saveCheckovResult = (state: vscode.Memento, checkovFails: FailedCheckovCheck[]): void => {
     const checkovMap = checkovFails.reduce((prev, current) => ({
@@ -33,7 +42,8 @@ export const getLogger = (logFileDir: string, logFileName: string): winston.Logg
         winston.format.splat(),
         winston.format.printf(({ level, message, ...rest }) => {
             const logError = rest.error ? { error: { ...rest.error, message: rest.error.message, stack: rest.error.stack } } : {};
-            return `[${level}]: ${message} ${JSON.stringify({ ...rest, ...logError })}`; 
+            const argumentsString = JSON.stringify({ ...rest, ...logError });
+            return `[${level}]: ${message} ${argumentsString !== '{}' ? argumentsString : ''}`; 
         })
     ),
     transports: [


### PR DESCRIPTION
**In This PR**
- Fix - run as-you-code scans only on terraform files (Needed to exclude log file changes )

- [x] I've reviewed my own code