### PR TITLE
fix(json,yml): support json+  yml, and empty file

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -4,4 +4,4 @@
 
 **Pictures/videos**
 
-- [] I've reviewed my own code
+- [ ] I've reviewed my own code

--- a/src/checkovRunner.ts
+++ b/src/checkovRunner.ts
@@ -57,7 +57,12 @@ export const runCheckovScan = (logger: Logger, fileName: string, token: string, 
             logger.debug(`Checkov scan process exited with code ${code}`);
             if (code !== 0) return reject(`Checkov exited with code ${code}`);
             
+            if (stdout.startsWith('[]')) {
+                logger.debug('Got an empty reply from checkov', { reply: stdout, fileName });
+                return resolve({ results: { failedChecks: [] } });
+            }
             const output: CheckovResponseRaw = JSON.parse(stdout);
+
             logger.debug('Checkov task output:', output);
 	
             resolve(parseCheckovResponse(output));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -121,7 +121,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
     // set code action provider
     context.subscriptions.push(
-        vscode.languages.registerCodeActionsProvider({ pattern: ' **/*.tf' }, 
+        vscode.languages.registerCodeActionsProvider({ pattern: ' **/*.{tf,yml,yaml,json}' }, 
             fixCodeActionProvider(context.workspaceState), { providedCodeActionKinds: providedCodeActionKinds })
     );
     

--- a/src/userInterface.ts
+++ b/src/userInterface.ts
@@ -27,7 +27,7 @@ ${logDirectoryPath}`;
 };
 
 export const showUnsupportedFileMessage = (): void => {
-    const message = 'Unsupported file type for Checkov scanning, We support .tf files only.';
+    const message = 'Unsupported file type for Checkov scanning, We support [.tf, .yml, .yaml, .json] files only.';
     vscode.window.showWarningMessage(message);
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,7 @@ export const asyncExec = async (commandToExecute: string) : Promise<ExecOutput> 
 };
 
 export const isSupportedFileType = (fileName: string, showMessage = false): boolean => {
-    if (!fileName.endsWith('.tf')) {
+    if (!(fileName.endsWith('.tf') || fileName.endsWith('.yml') || fileName.endsWith('.yaml') || fileName.endsWith('.json'))) {
         showMessage && showUnsupportedFileMessage();
         return false;
     }


### PR DESCRIPTION
**In This PR**
- Add support to `json`, `yaml`, and `yml` files.
- Handle empty file checkov response.
- Fix PR template file.

**Related links**
- https://bridgecrew.atlassian.net/browse/BC-3950

- [x] I've reviewed my own code