### PR TITLE
include param to remove container on the runner

### DIFF
--- a/src/checkovRunner.ts
+++ b/src/checkovRunner.ts
@@ -38,7 +38,7 @@ interface CheckovResponseRaw {
 const skipChecks = ['CKV_AWS_52'];
 
 const dockerMountDir = '/checkovScan';
-const getDockerRunParams = (filePath: string, extensionVersion: string) => ['run', '--tty', '--env', 'BC_SOURCE=vscode', '--env', `BC_SOURCE_VERSION=${extensionVersion}`, '--volume', `"${path.dirname(filePath)}:${dockerMountDir}"`, 'bridgecrew/checkov'];
+const getDockerRunParams = (filePath: string, extensionVersion: string) => ['run', ,'--rm', '--tty', '--env', 'BC_SOURCE=vscode', '--env', `BC_SOURCE_VERSION=${extensionVersion}`, '--volume', `"${path.dirname(filePath)}:${dockerMountDir}"`, 'bridgecrew/checkov'];
 
 const cleanupStdout = (stdout: string) => stdout.replace(/.\[0m/g,''); // Clean docker run ANSI escapse chars
 

--- a/src/checkovRunner.ts
+++ b/src/checkovRunner.ts
@@ -38,7 +38,7 @@ interface CheckovResponseRaw {
 const skipChecks = ['CKV_AWS_52'];
 
 const dockerMountDir = '/checkovScan';
-const getDockerRunParams = (filePath: string, extensionVersion: string) => ['run', ,'--rm', '--tty', '--env', 'BC_SOURCE=vscode', '--env', `BC_SOURCE_VERSION=${extensionVersion}`, '--volume', `"${path.dirname(filePath)}:${dockerMountDir}"`, 'bridgecrew/checkov'];
+const getDockerRunParams = (filePath: string, extensionVersion: string) => ['run', '--rm', '--tty', '--env', 'BC_SOURCE=vscode', '--env', `BC_SOURCE_VERSION=${extensionVersion}`, '--volume', `"${path.dirname(filePath)}:${dockerMountDir}"`, 'bridgecrew/checkov'];
 
 const cleanupStdout = (stdout: string) => stdout.replace(/.\[0m/g,''); // Clean docker run ANSI escapse chars
 


### PR DESCRIPTION
**In This PR**
- docker parameter to remove the docker container after check on the runner.

This will prevent to create hundreds of containers, as the Checkov creates a new container for every run.

Without that change, the user machine will looks like this:

```shell
> docker container ls -a
CONTAINER ID   IMAGE                COMMAND                  CREATED              STATUS                          PORTS     NAMES
286efb66ee54   bridgecrew/checkov   "checkov -s --skip-c…"   About a minute ago   Exited (0) 56 seconds ago                 suspicious_antonelli
befd916ce9d1   bridgecrew/checkov   "checkov -s --skip-c…"   About a minute ago   Exited (0) About a minute ago             funny_bartik
9fb956a9fa0f   bridgecrew/checkov   "checkov -s --skip-c…"   About a minute ago   Exited (0) About a minute ago             distracted_ride
09c61061aa38   bridgecrew/checkov   "checkov -s --skip-c…"   About a minute ago   Exited (0) About a minute ago             ecstatic_edison
e7fb0af49795   bridgecrew/checkov   "checkov -s --skip-c…"   About a minute ago   Exited (0) About a minute ago             inspiring_moore
... hundreds more ...
d0f2d93fc8a4   bridgecrew/checkov   "checkov -s --skip-c…"   About an hour ago    Exited (0) About an hour ago              hardcore_carson
f6e61a9058af   bridgecrew/checkov   "checkov -s --skip-c…"   About an hour ago    Exited (0) About an hour ago              reverent_johnson
cd9d8dad1e21   bridgecrew/checkov   "checkov -s --skip-c…"   About an hour ago    Exited (0) About an hour ago              fervent_feistel
555127cd9d1c   bridgecrew/checkov   "checkov -s --skip-c…"   About an hour ago    Exited (0) About an hour ago              sleepy_blackwell
b6d12a9538e5   bridgecrew/checkov   "checkov -s --skip-c…"   About an hour ago    Exited (0) About an hour ago              jolly_herschel
...
```

Fixes issue #41 