### PR TITLE
feat(CA-Cert): enable user to set custom ca cert and pass it to checkov

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,12 @@
           "type": "string",
           "markdownDescription": "In order to activate inline infrastructure-as-code fixes, you need to integrate with Bridgecrew's fixes API.   \n It's free to create an account and takes less than 2 minutes, Go to [Bridgecrew Platform](https://bridgecrew.cloud/) to get started.  \n Your API token can be found in the integrations tab, under \"API Token\". \n The extension will provide API access to the file, if checkov finds policy violations, in order to generate and supply the suggested fixes.",
           "readOnly": true
+        },
+        "checkov.certificate": {
+          "title": "Path to CA Certificate file",
+          "type": "string",
+          "markdownDescription": "[Optional] You can use custom CA-Certificate, set the path to it here.",
+          "readOnly": true
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "checkov.certificate": {
           "title": "Path to CA Certificate file",
           "type": "string",
-          "markdownDescription": "[Optional] You can use custom CA-Certificate, set the path to it here.",
+          "markdownDescription": "[Optional] You can use a custom CA-Certificate, set the path to it here.",
           "readOnly": true
         }
       }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -17,6 +17,6 @@ export const assureTokenSet = (logger: Logger, openConfigurationCommand: string)
 
 export const getPathToCert = (): string | undefined => {
     const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov');
-    const pathToCert = configuration.get<string>('cert');
+    const pathToCert = configuration.get<string>('certificate');
     return pathToCert;
 };

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -14,3 +14,9 @@ export const assureTokenSet = (logger: Logger, openConfigurationCommand: string)
     }
     return token;
 };
+
+export const getPathToCert = (): string | undefined => {
+    const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov');
+    const pathToCert = configuration.get<string>('cert');
+    return pathToCert;
+};


### PR DESCRIPTION
# In This PR
- Add `Certificate` to the settings
- If set, pass the cert to checkov using the `-ca` argument

## Pictures/videos
![image](https://user-images.githubusercontent.com/62605534/120987979-cfc0db80-c786-11eb-8356-1c8f154f8e75.png)

- [ ] I've reviewed my own code
