### PR TITLE
fix(docker run): add missing docker image name

### DIFF
--- a/src/checkovRunner.ts
+++ b/src/checkovRunner.ts
@@ -44,7 +44,7 @@ const getDockerRunParams = (filePath: string, extensionVersion: string, configFi
             '-v', `"${path.dirname(filePath)}:${dockerMountDir}"`, '-v', `"${path.dirname(configFilePath)}:${configMountDir}"`, 'bridgecrew/checkov',
             '--config-file', `${configMountDir}/${path.basename(configFilePath)}`] :
         ['run', '--rm', '--tty', '--env', 'BC_SOURCE=vscode', '--env', `BC_SOURCE_VERSION=${extensionVersion}`,
-            '-v', `"${path.dirname(filePath)}:${dockerMountDir}"`];
+            '-v', `"${path.dirname(filePath)}:${dockerMountDir}"`, 'bridgecrew/checkov'];
 };
 
 const getpipRunParams = (configFilePath: string | null) => {


### PR DESCRIPTION
# In This PR
- Add missing docker image name needed to invoke checkov run via docker
- Error was raised by a user in slack (https://codifiedsecurity.slack.com/archives/C01KPD735D3/p1624391600009200)

- [x] I've reviewed my own code
