### PR TITLE
fix(pipenv checkov): use most recent version

### DIFF
--- a/src/checkovInstaller.ts
+++ b/src/checkovInstaller.ts
@@ -36,7 +36,7 @@ const installOrUpdateCheckovWithPipenv = async (logger: Logger, installationDir:
     try {
         logger.info('Trying to install Checkov using pipenv.');
         fs.mkdirSync(installationDir, { recursive: true });
-        await asyncExec('pipenv --python 3 install checkov', { cwd: installationDir });
+        await asyncExec('pipenv --python 3 install checkov~=2.0.0', { cwd: installationDir });
         const checkovPath = 'pipenv run checkov';
         logger.info('Checkov installed successfully using pipenv.', { checkovPath });
         return checkovPath;


### PR DESCRIPTION
# In This PR
- Fix checkov scanning via pipenv resulting in 422
* pipenv is keeping semver versioning, meaning it will not update the version to a higher major (major.minor.patch)
So since we updaed to version 2 of checkov it didn’t update and ran on checkov 1.0.821
Recently we changed the bridgecrew api schema validation and the endpoint didn’t get something that was marked as required, resulting in 422 error Validation Failed

- [ ] I've reviewed my own code
