### PR TITLE
Pin checkov version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -151,6 +151,11 @@
 			"integrity": "sha512-o3oj1bETk8kBwzz1WlO6JWL/AfAA3Vm6J1B3C9CsdxHYp7XgPiH7OEXPUbZTndHlRaIElrANkQfe6ZmfJb3H2w==",
 			"dev": true
 		},
+		"@types/semver": {
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now=="
+		},
 		"@types/vscode": {
 			"version": "1.52.0",
 			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
@@ -1212,6 +1217,14 @@
 				"triple-beam": "^1.3.0"
 			}
 		},
+		"lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"requires": {
+				"yallist": "^4.0.0"
+			}
+		},
 		"merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1527,10 +1540,12 @@
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 		},
 		"semver": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-			"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-			"dev": true
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"requires": {
+				"lru-cache": "^6.0.0"
+			}
 		},
 		"serialize-javascript": {
 			"version": "5.0.1",
@@ -1927,6 +1942,11 @@
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
 			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
 			"dev": true
+		},
+		"yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"yargs": {
 			"version": "13.3.2",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,19 @@
           "type": "boolean",
           "markdownDescription": "Whether to use Bridgecrew platform IDs (BC_...) instead of Checkov IDs (CKV_...)",
           "readOnly": true
+        },
+        "checkov.autoUpdateCheckov": {
+          "title": "Auto-update checkov",
+          "type": "boolean",
+          "markdownDescription": "Whether to pull the latest Checkov version before scanning. This option is ignored if a version is specified below. If unchecked, then use whatever version is currently installed or specified below. After changing this option, be sure to run the 'Install or Update Checkov' command.",
+          "readOnly": true,
+          "default": true
+        },
+        "checkov.checkovVersion": {
+          "title": "Checkov version",
+          "type": "string",
+          "markdownDescription": "The checkov version to use (e.g., 2.0.123). If specified, then auto-update is ignored. After changing this option, be sure to run the 'Install or Update Checkov' command.",
+          "readOnly": true
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
           "type": "string",
           "markdownDescription": "The Checkov scanner version to use (e.g., 2.0.123). Enter 'latest' or leave blank to always use the latest version. Be sure to run the 'Install or Update Checkov' command after changing this value. Use the 'About Checkov' to view the current version.",
           "readOnly": true
+        },
         "checkov.disableErrorMessage": {
           "title": "Disable error message",
           "markdownDescription": "Stop showing error messages.",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@types/js-yaml": "^4.0.1",
     "@types/lodash": "^4.14.168",
     "@types/mocha": "^8.0.0",
+    "@types/semver": "^7.3.8",
     "@types/node": "^12.11.7",
     "@types/vscode": "^1.48.2",
     "@typescript-eslint/eslint-plugin": "^4.1.1",
@@ -101,7 +102,6 @@
     "vscode-test": "^1.4.0"
   },
   "dependencies": {
-    "@types/semver": "^7.3.8",
     "lodash": "^4.17.21",
     "semver": "^7.3.5",
     "winston": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,10 @@
       {
         "command": "checkov.about-checkov",
         "title": "About Checkov"
+      },
+      {
+        "command": "checkov.open-log",
+        "title": "Open Checkov Log"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,9 @@
     "vscode-test": "^1.4.0"
   },
   "dependencies": {
+    "@types/semver": "^7.3.8",
     "lodash": "^4.17.21",
+    "semver": "^7.3.5",
     "winston": "^3.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,11 +39,15 @@
       },
       {
         "command": "checkov.install-or-update-checkov",
-        "title": "Install Or Update Checkov"
+        "title": "Install or Update Checkov"
       },
       {
         "command": "checkov.configuration.open",
-        "title": "Open settings for Checkov extension"
+        "title": "Open Checkov Settings"
+      },
+      {
+        "command": "checkov.about-checkov",
+        "title": "About Checkov"
       }
     ],
     "configuration": {
@@ -70,7 +74,7 @@
         "checkov.checkovVersion": {
           "title": "Checkov version",
           "type": "string",
-          "markdownDescription": "The checkov version to use (e.g., 2.0.123). Enter 'latest' or leave blank to always use the latest version. Be sure to run the 'Install or Update Checkov' command after changing this value. Use the 'Get Checkov Installation Details' to view the current version.",
+          "markdownDescription": "The Checkov scanner version to use (e.g., 2.0.123). Enter 'latest' or leave blank to always use the latest version. Be sure to run the 'Install or Update Checkov' command after changing this value. Use the 'About Checkov' to view the current version.",
           "readOnly": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -78,12 +78,12 @@
         "checkov.checkovVersion": {
           "title": "Checkov version",
           "type": "string",
-          "markdownDescription": "The Checkov scanner version to use (e.g., 2.0.123). Enter 'latest' or leave blank to always use the latest version. Be sure to run the 'Install or Update Checkov' command after changing this value. Use the 'About Checkov' to view the current version.",
+          "markdownDescription": "The Checkov scanner version to use (e.g., 2.0.123). Enter 'latest' or leave blank to always use the latest version. Be sure to run the 'Install or Update Checkov' command after changing this value. Use the 'About Checkov' command to view the current version.",
           "readOnly": true
         },
         "checkov.disableErrorMessage": {
           "title": "Disable error message",
-          "markdownDescription": "Stop showing error messages.",
+          "markdownDescription": "Stop showing error message popups (use the 'Open Checkov Log' command to view the log).",
           "type": "boolean",
           "default": false
         }

--- a/package.json
+++ b/package.json
@@ -67,17 +67,10 @@
           "markdownDescription": "Whether to use Bridgecrew platform IDs (BC_...) instead of Checkov IDs (CKV_...)",
           "readOnly": true
         },
-        "checkov.autoUpdateCheckov": {
-          "title": "Auto-update checkov",
-          "type": "boolean",
-          "markdownDescription": "Whether to pull the latest Checkov version before scanning. This option is ignored if a version is specified below. If unchecked, then use whatever version is currently installed or specified below. After changing this option, be sure to run the 'Install or Update Checkov' command.",
-          "readOnly": true,
-          "default": true
-        },
         "checkov.checkovVersion": {
           "title": "Checkov version",
           "type": "string",
-          "markdownDescription": "The checkov version to use (e.g., 2.0.123). If specified, then auto-update is ignored. After changing this option, be sure to run the 'Install or Update Checkov' command.",
+          "markdownDescription": "The checkov version to use (e.g., 2.0.123). Enter 'latest' or leave blank to always use the latest version. Be sure to run the 'Install or Update Checkov' command after changing this value. Use the 'Get Checkov Installation Details' to view the current version.",
           "readOnly": true
         }
       }

--- a/src/checkovInstaller.ts
+++ b/src/checkovInstaller.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { Logger } from 'winston';
-import { getCheckovVersion } from './configuration';
 import { asyncExec } from './utils';
 
 const isCheckovInstalledGlobally = async () => {
@@ -81,9 +80,7 @@ export interface CheckovInstallation {
     version?: string;
 }
 
-export const installOrUpdateCheckov = async (logger: Logger, installationDir: string): Promise<CheckovInstallation> => {
-    const checkovVersion = getCheckovVersion();
-
+export const installOrUpdateCheckov = async (logger: Logger, installationDir: string, checkovVersion: string): Promise<CheckovInstallation> => {
     const dockerCheckovPath = await installOrUpdateCheckovWithDocker(logger, checkovVersion);
     if (dockerCheckovPath) return { checkovInstallationMethod: 'docker' , checkovPath: dockerCheckovPath };
     const pip3CheckovPath = await installOrUpdateCheckovWithPip3(logger, checkovVersion);

--- a/src/checkovInstaller.ts
+++ b/src/checkovInstaller.ts
@@ -189,13 +189,13 @@ export const installOrUpdateCheckov = async (logger: Logger, installationDir: st
 
     let installation: CheckovInstallation | null = null;
 
-    // const dockerCheckovPath = await installOrUpdateCheckovWithDocker(logger, autoUpdate, checkovVersion);
-    // if (dockerCheckovPath) installation = { checkovInstallationMethod: 'docker' , checkovPath: dockerCheckovPath, version: checkovVersion };
+    const dockerCheckovPath = await installOrUpdateCheckovWithDocker(logger, autoUpdate, checkovVersion);
+    if (dockerCheckovPath) installation = { checkovInstallationMethod: 'docker' , checkovPath: dockerCheckovPath, version: checkovVersion };
 
-    // if (!installation) {
-    //     const pip3CheckovPath = await installOrUpdateCheckovWithPip3(logger, autoUpdate, checkovVersion);
-    //     if (pip3CheckovPath) installation = { checkovInstallationMethod: 'pip3' , checkovPath: pip3CheckovPath };
-    // }
+    if (!installation) {
+        const pip3CheckovPath = await installOrUpdateCheckovWithPip3(logger, autoUpdate, checkovVersion);
+        if (pip3CheckovPath) installation = { checkovInstallationMethod: 'pip3' , checkovPath: pip3CheckovPath };
+    }
 
     if (!installation) {
         const pipenvCheckovPath = await installOrUpdateCheckovWithPipenv(logger, installationDir, autoUpdate, checkovVersion);

--- a/src/checkovInstaller.ts
+++ b/src/checkovInstaller.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Logger } from 'winston';
 import { getCheckovVersion } from './configuration';
-import { asyncExec, runVersionCommand } from './utils';
+import { asyncExec } from './utils';
 
 const isCheckovInstalledGlobally = async () => {
     try {

--- a/src/checkovInstaller.ts
+++ b/src/checkovInstaller.ts
@@ -4,8 +4,6 @@ import { Logger } from 'winston';
 import { getAutoUpdate, getCheckovVersion } from './configuration';
 import { asyncExec, runVersionCommand } from './utils';
 
-export const minCheckovVersion = '2.0.0';
-
 const isCheckovInstalledGlobally = async () => {
     try {
         await asyncExec('checkov --version');

--- a/src/checkovInstaller.ts
+++ b/src/checkovInstaller.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as vscode from 'vscode';
 import { Logger } from 'winston';
 import { getAutoUpdate, getCheckovVersion } from './configuration';
 import { asyncExec, runVersionCommand } from './utils';

--- a/src/checkovInstaller.ts
+++ b/src/checkovInstaller.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { Logger } from 'winston';
-import { getAutoUpdate, getCheckovVersion } from './configuration';
+import { getCheckovVersion } from './configuration';
 import { asyncExec, runVersionCommand } from './utils';
 
 const isCheckovInstalledGlobally = async () => {
@@ -13,68 +13,12 @@ const isCheckovInstalledGlobally = async () => {
     }
 };
 
-const validateCheckovVersion = (checkovVersion: string | undefined) => {
-    // validates that the version is >= the min version (or it can be null)
-    // does NOT validate that the version actually exists (this will happen during the actual installation)
-    // assumes the value came from getCheckovVersion helper method
-    // a normal return indicates the version is valid, otherwise an error is thrown
-
-    if (!checkovVersion) {
-        return;
-    }
-
-    const parts = checkovVersion.split('.').map(i => parseInt(i));
-    if (parts.length !== 3) {
-        throw new Error(`Invalid specified checkov version: ${checkovVersion} (expected format #.#.#)`);
-    }
-
-    const minVersion = minCheckovVersion.split('.').map(i => parseInt(i));
-
-    let aboveMinimum = true;
-
-    for (let index = 0; index < 3; index++) {
-        // Validate left to right until we find a mismatch (also make sure we parsed actual numbers)
-        if (isNaN(parts[index])) {
-            throw new Error(`Invalid specified checkov version ${checkovVersion} (expected format #.#.#)`);
-        }
-
-        if (parts[index] > minVersion[index]) {
-            // all previous parts were ==, so this means we are above the minimum
-            break;
-        }
-        else if (parts[index] < minVersion[index]) {
-            // all previous parts were ==, so this means we are below the minimum
-            aboveMinimum = false;
-            break;
-        }
-    }
-
-    if (!aboveMinimum) {
-        throw new Error(`Checkov version ${checkovVersion} is below the minimum supported version of ${minCheckovVersion}`);
-    }
-};
-
-const installOrUpdateCheckovWithPip3 = async (logger: Logger, autoUpdate: boolean, checkovVersion: string | undefined): Promise<string | null> => {
+const installOrUpdateCheckovWithPip3 = async (logger: Logger, checkovVersion: string): Promise<string | null> => {
     logger.info('Trying to install Checkov using pip3.');
 
-    // Pip version logic:
-    // if a version is specified, install that ('pip install checkov==1.2.3' will remove any other version)
-    // otherwise, if autoupdate is true, then run with -U and no version
-    // otherwise just run 'pip install checkov', which will do nothing (other than validate that the pip3 installation works) 
-    // if any version is installed.
-
     try {
-        let command = 'pip3 install --user --verbose ';
-        if (checkovVersion) {
-            command += `checkov==${checkovVersion} `;
-        } else if (autoUpdate) {
-            command += '-U checkov ';
-        } else {
-            command += 'checkov ';
-        }
-        command += '-i https://pypi.org/simple/';
-
-        logger.debug(`Testing pip3 installation with the command: ${command}`);
+        const command = `pip3 install --user -U -i https://pypi.org/simple/ checkov${checkovVersion === 'latest' ? '' : `==${checkovVersion}`}`;
+        logger.debug(`Testing pip3 installation with command: ${command}`);
         await asyncExec(command);
 
         let checkovPath;
@@ -92,37 +36,17 @@ const installOrUpdateCheckovWithPip3 = async (logger: Logger, autoUpdate: boolea
     }
 };
 
-const installOrUpdateCheckovWithPipenv = async (logger: Logger, installationDir: string, autoUpdate: boolean, checkovVersion: string | undefined): Promise<string | null> => {
-    
-    // pipenv version logic:
-    // if a version is specified, run pipenv install checkov==1.2.3
-    // otherwise, if autoupdate is true, run pipenv install checkov~=2.0.0 (will upgrade if needed)
-    // otherwise, since pipenv does not have a way to "install" without upgrading, we have to do a workaround.
+const installOrUpdateCheckovWithPipenv = async (logger: Logger, installationDir: string, checkovVersion: string): Promise<string | null> => {
     
     logger.info('Trying to install Checkov using pipenv.');
 
     try {
         fs.mkdirSync(installationDir, { recursive: true });
 
-        if (!autoUpdate && !checkovVersion) {
-            // auto-update is off, and there is no pinned version, so we have to see if checkov is already installed
-            // with pipenv; if it is, then we should be able to run it and it will work.
-            // if it's not, then we will just try installing it below
-            // this is a workaround to the issue described above
-            try {
-                logger.debug('Auto update is false with no pinned version - attempting pipenv run checkov to see if it is installed');
-                await asyncExec('pipenv run checkov -v', { cwd: installationDir });
-            } catch (error) {
-                logger.debug('pipenv run checkov failed - will attempt to install checkov with pipenv');
-                autoUpdate = true; // allow the next block to run as if this is a first-time installation
-            }
-        }
-
-        if (autoUpdate || checkovVersion) {
-            const version = checkovVersion ? `==${checkovVersion}` : '~=2.0.0';
-            logger.debug(`Attempting pipenv install checkov${version}`);
-            await asyncExec(`pipenv --python 3 install checkov${version}`, { cwd: installationDir });
-        }
+        const version = checkovVersion ? `==${checkovVersion}` : '~=2.0.0';
+        const command = `pipenv --python 3 install checkov${version}`;
+        logger.debug('Testing pipenv installation with command: ', command);
+        await asyncExec(command, { cwd: installationDir });
 
         const checkovPath = 'pipenv run checkov';
         logger.info('Checkov installed successfully using pipenv.', { checkovPath, installationDir });
@@ -133,30 +57,19 @@ const installOrUpdateCheckovWithPipenv = async (logger: Logger, installationDir:
     }
 };
 
-const installOrUpdateCheckovWithDocker = async (logger: Logger, autoUpdate: boolean, checkovVersion: string | undefined): Promise<string | null> => {
+const installOrUpdateCheckovWithDocker = async (logger: Logger, checkovVersion: string): Promise<string | null> => {
     
-    // Docker version logic:
-    // If a version is specified, pull that version.
-    // Otherwise, if auto-update is true, pull latest.
-    // Otherwise, do not pull anything (but use `run` to ensure we have it locally)
-
     logger.info('Trying to install Checkov using Docker.');
     try {
-        if (!autoUpdate && !checkovVersion) {
-            logger.debug('Auto-update is false and there is no specified version; using whatever the local latest tag is');
-            // This command will pull latest if this is the first time run, otherwise it will use what's there without updating it
-            // This is the best way to validate that we have a runnable checkov image using docker
-            await asyncExec('docker run bridgecrew/checkov:latest -v');
-        } else {
-            const tag = checkovVersion || 'latest';
-            logger.debug(`Attempting to pull docker bridgecrew/checkov:${tag}`);
-            await asyncExec(`docker pull bridgecrew/checkov:${tag}`);
-        }
+        const command = `docker pull bridgecrew/checkov:${checkovVersion}`;
+        logger.debug(`Testing docker installation with command: ${command}`);
+        await asyncExec(command);
+        
         const checkovPath = 'docker';
         logger.info('Checkov installed successfully using Docker.', { checkovPath });
         return checkovPath;
     } catch (error) {
-        logger.error('Failed to install or update Checkov using Docker. Error:', { error });
+        logger.error('Failed to install or update Checkov using Docker. Error: ', { error });
         return null;
     }
 };
@@ -170,36 +83,14 @@ export interface CheckovInstallation {
 }
 
 export const installOrUpdateCheckov = async (logger: Logger, installationDir: string): Promise<CheckovInstallation> => {
-    const autoUpdate = getAutoUpdate();
     const checkovVersion = getCheckovVersion();
 
-    validateCheckovVersion(checkovVersion);
+    const dockerCheckovPath = await installOrUpdateCheckovWithDocker(logger, checkovVersion);
+    if (dockerCheckovPath) return { checkovInstallationMethod: 'docker' , checkovPath: dockerCheckovPath };
+    const pip3CheckovPath = await installOrUpdateCheckovWithPip3(logger, checkovVersion);
+    if (pip3CheckovPath) return { checkovInstallationMethod: 'pip3' , checkovPath: pip3CheckovPath };
+    const pipenvCheckovPath = await installOrUpdateCheckovWithPipenv(logger, installationDir, checkovVersion);
+    if (pipenvCheckovPath) return { checkovInstallationMethod: 'pipenv' , checkovPath: pipenvCheckovPath, workingDir: installationDir };
 
-    // when we attempt to install checkov, the method that succeeds determines the return value of this method.
-    // thus, we still need to run these methods, even if autoUpdate is false or there is a pinned checkov version,
-    // otherwise the plugin will not know which command to use
-    // the logic is a little different for each installer, so it's hard to reuse here
-
-    let installation: CheckovInstallation | null = null;
-
-    const dockerCheckovPath = await installOrUpdateCheckovWithDocker(logger, autoUpdate, checkovVersion);
-    if (dockerCheckovPath) installation = { checkovInstallationMethod: 'docker' , checkovPath: dockerCheckovPath, version: checkovVersion };
-
-    if (!installation) {
-        const pip3CheckovPath = await installOrUpdateCheckovWithPip3(logger, autoUpdate, checkovVersion);
-        if (pip3CheckovPath) installation = { checkovInstallationMethod: 'pip3' , checkovPath: pip3CheckovPath };
-    }
-
-    if (!installation) {
-        const pipenvCheckovPath = await installOrUpdateCheckovWithPipenv(logger, installationDir, autoUpdate, checkovVersion);
-        if (pipenvCheckovPath) installation = { checkovInstallationMethod: 'pipenv' , checkovPath: pipenvCheckovPath, workingDir: installationDir };
-    }
-
-    if (installation) {
-        logger.debug('Checkov installation: ', installation);
-        runVersionCommand(logger, installation.checkovPath, installation.workingDir);
-        return installation;
-    } else {
-        throw new Error('Could not install Checkov.');
-    }
+    throw new Error('Could not install Checkov.');
 };

--- a/src/checkovInstaller.ts
+++ b/src/checkovInstaller.ts
@@ -149,18 +149,14 @@ const installOrUpdateCheckovWithDocker = async (logger: Logger, autoUpdate: bool
             // This command will pull latest if this is the first time run, otherwise it will use what's there without updating it
             // This is the best way to validate that we have a runnable checkov image using docker
             await asyncExec('docker run bridgecrew/checkov:latest -v');
-            const checkovPath = 'docker';
-            logger.info('Checkov installed successfully using Docker.', { checkovPath });
-            return checkovPath;
-            
         } else {
             const tag = checkovVersion || 'latest';
             logger.debug(`Attempting to pull docker bridgecrew/checkov:${tag}`);
             await asyncExec(`docker pull bridgecrew/checkov:${tag}`);
-            const checkovPath = 'docker';
-            logger.info('Checkov installed successfully using Docker.', { checkovPath });
-            return checkovPath;
         }
+        const checkovPath = 'docker';
+        logger.info('Checkov installed successfully using Docker.', { checkovPath });
+        return checkovPath;
     } catch (error) {
         logger.error('Failed to install or update Checkov using Docker. Error:', { error });
         return null;

--- a/src/checkovInstaller.ts
+++ b/src/checkovInstaller.ts
@@ -43,8 +43,7 @@ const installOrUpdateCheckovWithPipenv = async (logger: Logger, installationDir:
     try {
         fs.mkdirSync(installationDir, { recursive: true });
 
-        const version = checkovVersion ? `==${checkovVersion}` : '~=2.0.0';
-        const command = `pipenv --python 3 install checkov${version}`;
+        const command = `pipenv --python 3 install checkov${checkovVersion ? `==${checkovVersion}` : '~=2.0.0'}`;
         logger.debug('Testing pipenv installation with command: ', command);
         await asyncExec(command, { cwd: installationDir });
 

--- a/src/checkovInstaller.ts
+++ b/src/checkovInstaller.ts
@@ -1,7 +1,11 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import * as vscode from 'vscode';
 import { Logger } from 'winston';
-import { asyncExec } from './utils';
+import { getAutoUpdate, getCheckovVersion } from './configuration';
+import { asyncExec, runVersionCommand } from './utils';
+
+export const minCheckovVersion = '2.0.0';
 
 const isCheckovInstalledGlobally = async () => {
     try {
@@ -12,19 +16,78 @@ const isCheckovInstalledGlobally = async () => {
     }
 };
 
-const installOrUpdateCheckovWithPip3 = async (logger: Logger): Promise<string | null> => {
-    try {
-        logger.info('Trying to install Checkov using pip3.');
-        await asyncExec('pip3 install -U --user --verbose checkov -i https://pypi.org/simple/');
+const validateCheckovVersion = (checkovVersion: string | undefined) => {
+    // validates that the version is >= the min version (or it can be null)
+    // does NOT validate that the version actually exists (this will happen during the actual installation)
+    // assumes the value came from getCheckovVersion helper method
+    // a normal return indicates the version is valid, otherwise an error is thrown
 
-        if (await isCheckovInstalledGlobally()) {
-            const checkovPath = 'checkov';
-            logger.info('Checkov installed successfully using pip3.', { checkovPath });
-            return checkovPath;
+    if (!checkovVersion) {
+        return;
+    }
+
+    const parts = checkovVersion.split('.').map(i => parseInt(i));
+    if (parts.length !== 3) {
+        throw new Error(`Invalid specified checkov version: ${checkovVersion} (expected format #.#.#)`);
+    }
+
+    const minVersion = minCheckovVersion.split('.').map(i => parseInt(i));
+
+    let aboveMinimum = true;
+
+    for (let index = 0; index < 3; index++) {
+        // Validate left to right until we find a mismatch (also make sure we parsed actual numbers)
+        if (isNaN(parts[index])) {
+            throw new Error(`Invalid specified checkov version ${checkovVersion} (expected format #.#.#)`);
         }
 
-        const [pythonUserBaseOutput] = await asyncExec('python3 -c "import site; print(site.USER_BASE)"');
-        const checkovPath = path.join(pythonUserBaseOutput.trim(), 'bin', 'checkov');
+        if (parts[index] > minVersion[index]) {
+            // all previous parts were ==, so this means we are above the minimum
+            break;
+        }
+        else if (parts[index] < minVersion[index]) {
+            // all previous parts were ==, so this means we are below the minimum
+            aboveMinimum = false;
+            break;
+        }
+    }
+
+    if (!aboveMinimum) {
+        throw new Error(`Checkov version ${checkovVersion} is below the minimum supported version of ${minCheckovVersion}`);
+    }
+};
+
+const installOrUpdateCheckovWithPip3 = async (logger: Logger, autoUpdate: boolean, checkovVersion: string | undefined): Promise<string | null> => {
+    logger.info('Trying to install Checkov using pip3.');
+
+    // Pip version logic:
+    // if a version is specified, install that ('pip install checkov==1.2.3' will remove any other version)
+    // otherwise, if autoupdate is true, then run with -U and no version
+    // otherwise just run 'pip install checkov', which will do nothing (other than validate that the pip3 installation works) 
+    // if any version is installed.
+
+    try {
+        let command = 'pip3 install --user --verbose ';
+        if (checkovVersion) {
+            command += `checkov==${checkovVersion} `;
+        } else if (autoUpdate) {
+            command += '-U checkov ';
+        } else {
+            command += 'checkov ';
+        }
+        command += '-i https://pypi.org/simple/';
+
+        logger.debug(`Testing pip3 installation with the command: ${command}`);
+        await asyncExec(command);
+
+        let checkovPath;
+        if (await isCheckovInstalledGlobally()) {
+            checkovPath = 'checkov';
+        } else {
+            const [pythonUserBaseOutput] = await asyncExec('python3 -c "import site; print(site.USER_BASE)"');
+            checkovPath = path.join(pythonUserBaseOutput.trim(), 'bin', 'checkov');
+        }
+        logger.info('Checkov installed successfully using pip3.', { checkovPath });
         return checkovPath;
     } catch (error) {
         logger.error('Failed to install or update Checkov using pip3. Error:', { error });
@@ -32,13 +95,40 @@ const installOrUpdateCheckovWithPip3 = async (logger: Logger): Promise<string | 
     }
 };
 
-const installOrUpdateCheckovWithPipenv = async (logger: Logger, installationDir: string): Promise<string | null> => {
+const installOrUpdateCheckovWithPipenv = async (logger: Logger, installationDir: string, autoUpdate: boolean, checkovVersion: string | undefined): Promise<string | null> => {
+    
+    // pipenv version logic:
+    // if a version is specified, run pipenv install checkov==1.2.3
+    // otherwise, if autoupdate is true, run pipenv install checkov~=2.0.0 (will upgrade if needed)
+    // otherwise, since pipenv does not have a way to "install" without upgrading, we have to do a workaround.
+    
+    logger.info('Trying to install Checkov using pipenv.');
+
     try {
-        logger.info('Trying to install Checkov using pipenv.');
         fs.mkdirSync(installationDir, { recursive: true });
-        await asyncExec('pipenv --python 3 install checkov~=2.0.0', { cwd: installationDir });
+
+        if (!autoUpdate && !checkovVersion) {
+            // auto-update is off, and there is no pinned version, so we have to see if checkov is already installed
+            // with pipenv; if it is, then we should be able to run it and it will work.
+            // if it's not, then we will just try installing it below
+            // this is a workaround to the issue described above
+            try {
+                logger.debug('Auto update is false with no pinned version - attempting pipenv run checkov to see if it is installed');
+                await asyncExec('pipenv run checkov -v', { cwd: installationDir });
+            } catch (error) {
+                logger.debug('pipenv run checkov failed - will attempt to install checkov with pipenv');
+                autoUpdate = true; // allow the next block to run as if this is a first-time installation
+            }
+        }
+
+        if (autoUpdate || checkovVersion) {
+            const version = checkovVersion ? `==${checkovVersion}` : '~=2.0.0';
+            logger.debug(`Attempting pipenv install checkov${version}`);
+            await asyncExec(`pipenv --python 3 install checkov${version}`, { cwd: installationDir });
+        }
+
         const checkovPath = 'pipenv run checkov';
-        logger.info('Checkov installed successfully using pipenv.', { checkovPath });
+        logger.info('Checkov installed successfully using pipenv.', { checkovPath, installationDir });
         return checkovPath;
     } catch (error) {
         logger.error('Failed to install or update Checkov using pipenv. Error:', { error });
@@ -46,13 +136,32 @@ const installOrUpdateCheckovWithPipenv = async (logger: Logger, installationDir:
     }
 };
 
-const installOrUpdateCheckovWithDocker = async (logger: Logger): Promise<string | null> => {
+const installOrUpdateCheckovWithDocker = async (logger: Logger, autoUpdate: boolean, checkovVersion: string | undefined): Promise<string | null> => {
+    
+    // Docker version logic:
+    // If a version is specified, pull that version.
+    // Otherwise, if auto-update is true, pull latest.
+    // Otherwise, do not pull anything (but use `run` to ensure we have it locally)
+
+    logger.info('Trying to install Checkov using Docker.');
     try {
-        logger.info('Trying to install Checkov using Docker.');
-        await asyncExec('docker pull bridgecrew/checkov:latest');
-        const checkovPath = 'docker';
-        logger.info('Checkov installed successfully using Docker.', { checkovPath });
-        return checkovPath;
+        if (!autoUpdate && !checkovVersion) {
+            logger.debug('Auto-update is false and there is no specified version; using whatever the local latest tag is');
+            // This command will pull latest if this is the first time run, otherwise it will use what's there without updating it
+            // This is the best way to validate that we have a runnable checkov image using docker
+            await asyncExec('docker run bridgecrew/checkov:latest -v');
+            const checkovPath = 'docker';
+            logger.info('Checkov installed successfully using Docker.', { checkovPath });
+            return checkovPath;
+            
+        } else {
+            const tag = checkovVersion || 'latest';
+            logger.debug(`Attempting to pull docker bridgecrew/checkov:${tag}`);
+            await asyncExec(`docker pull bridgecrew/checkov:${tag}`);
+            const checkovPath = 'docker';
+            logger.info('Checkov installed successfully using Docker.', { checkovPath });
+            return checkovPath;
+        }
     } catch (error) {
         logger.error('Failed to install or update Checkov using Docker. Error:', { error });
         return null;
@@ -64,15 +173,40 @@ export interface CheckovInstallation {
     checkovInstallationMethod: CheckovInstallationMethod;
     checkovPath: string;
     workingDir?: string;
+    version?: string;
 }
 
 export const installOrUpdateCheckov = async (logger: Logger, installationDir: string): Promise<CheckovInstallation> => {
-    const dockerCheckovPath = await installOrUpdateCheckovWithDocker(logger);
-    if (dockerCheckovPath) return { checkovInstallationMethod: 'docker' , checkovPath: dockerCheckovPath };
-    const pip3CheckovPath = await installOrUpdateCheckovWithPip3(logger);
-    if (pip3CheckovPath) return { checkovInstallationMethod: 'pip3' , checkovPath: pip3CheckovPath };
-    const pipenvCheckovPath = await installOrUpdateCheckovWithPipenv(logger, installationDir);
-    if (pipenvCheckovPath) return { checkovInstallationMethod: 'pipenv' , checkovPath: pipenvCheckovPath, workingDir: installationDir };
+    const autoUpdate = getAutoUpdate();
+    const checkovVersion = getCheckovVersion();
 
-    throw new Error('Could not install Checkov.');
+    validateCheckovVersion(checkovVersion);
+
+    // when we attempt to install checkov, the method that succeeds determines the return value of this method.
+    // thus, we still need to run these methods, even if autoUpdate is false or there is a pinned checkov version,
+    // otherwise the plugin will not know which command to use
+    // the logic is a little different for each installer, so it's hard to reuse here
+
+    let installation: CheckovInstallation | null = null;
+
+    // const dockerCheckovPath = await installOrUpdateCheckovWithDocker(logger, autoUpdate, checkovVersion);
+    // if (dockerCheckovPath) installation = { checkovInstallationMethod: 'docker' , checkovPath: dockerCheckovPath, version: checkovVersion };
+
+    // if (!installation) {
+    //     const pip3CheckovPath = await installOrUpdateCheckovWithPip3(logger, autoUpdate, checkovVersion);
+    //     if (pip3CheckovPath) installation = { checkovInstallationMethod: 'pip3' , checkovPath: pip3CheckovPath };
+    // }
+
+    if (!installation) {
+        const pipenvCheckovPath = await installOrUpdateCheckovWithPipenv(logger, installationDir, autoUpdate, checkovVersion);
+        if (pipenvCheckovPath) installation = { checkovInstallationMethod: 'pipenv' , checkovPath: pipenvCheckovPath, workingDir: installationDir };
+    }
+
+    if (installation) {
+        logger.debug('Checkov installation: ', installation);
+        runVersionCommand(logger, installation.checkovPath, installation.workingDir);
+        return installation;
+    } else {
+        throw new Error('Could not install Checkov.');
+    }
 };

--- a/src/checkovRunner.ts
+++ b/src/checkovRunner.ts
@@ -57,7 +57,7 @@ const getpipRunParams = (configFilePath: string | null) => {
 const cleanupStdout = (stdout: string) => stdout.replace(/.\[0m/g,''); // Clean docker run ANSI escapse chars
 
 export const runCheckovScan = (logger: Logger, checkovInstallation: CheckovInstallation, extensionVersion: string, fileName: string, token: string, 
-    certPath: string | undefined, useBcIds: boolean | undefined, cancelToken: vscode.CancellationToken, configPath: string | null): Promise<CheckovResponse> => {
+    certPath: string | undefined, useBcIds: boolean | undefined, cancelToken: vscode.CancellationToken, configPath: string | null, checkovVersion: string): Promise<CheckovResponse> => {
     return new Promise((resolve, reject) => {   
         const { checkovInstallationMethod, checkovPath, workingDir } = checkovInstallation;
 
@@ -71,7 +71,7 @@ export const runCheckovScan = (logger: Logger, checkovInstallation: CheckovInsta
         logger.info('Running checkov:');
         logger.info(`${checkovPath} ${checkovArguments.map(argument => argument === token ? '****' : argument).join(' ')}`);
         
-        runVersionCommand(logger, checkovPath, checkovInstallation.workingDir);
+        runVersionCommand(logger, checkovPath, checkovVersion, checkovInstallation.workingDir);
         
         const ckv = spawn(checkovPath, checkovArguments,
             {

--- a/src/checkovRunner.ts
+++ b/src/checkovRunner.ts
@@ -40,13 +40,14 @@ const dockerMountDir = '/checkovScan';
 const configMountDir = '/checkovConfig';
 
 const getDockerRunParams = (filePath: string, extensionVersion: string, configFilePath: string | null, checkovVersion: string | undefined) => {
-    const image = checkovVersion ? `bridgecrew/checkov:${checkovVersion}` : 'bridgecrew/checkov';
+    const image = `bridgecrew/checkov:${checkovVersion}`;
+    const params = ['run', '--rm', '--tty', '--env', 'BC_SOURCE=vscode', '--env', `BC_SOURCE_VERSION=${extensionVersion}`,
+        '-v', `"${path.dirname(filePath)}:${dockerMountDir}"`];
+    
     return configFilePath ?
-        ['run', '--rm', '--tty', '--env', 'BC_SOURCE=vscode', '--env', `BC_SOURCE_VERSION=${extensionVersion}`,
-            '-v', `"${path.dirname(filePath)}:${dockerMountDir}"`, '-v', `"${path.dirname(configFilePath)}:${configMountDir}"`, image,
+        [...params, '-v', `"${path.dirname(configFilePath)}:${configMountDir}"`, image, 
             '--config-file', `${configMountDir}/${path.basename(configFilePath)}`] :
-        ['run', '--rm', '--tty', '--env', 'BC_SOURCE=vscode', '--env', `BC_SOURCE_VERSION=${extensionVersion}`,
-            '-v', `"${path.dirname(filePath)}:${dockerMountDir}"`, image];
+        [...params, image];
 };
 
 const getpipRunParams = (configFilePath: string | null) => {

--- a/src/checkovRunner.ts
+++ b/src/checkovRunner.ts
@@ -3,7 +3,7 @@ import { spawn } from 'child_process';
 import * as path from 'path';
 import { Logger } from 'winston';
 import { CheckovInstallation } from './checkovInstaller';
-import { convertToUnixPath } from './utils';
+import { convertToUnixPath, runVersionCommand } from './utils';
 
 export interface FailedCheckovCheck {
     checkId: string;
@@ -39,13 +39,14 @@ interface CheckovResponseRaw {
 const dockerMountDir = '/checkovScan';
 const configMountDir = '/checkovConfig';
 
-const getDockerRunParams = (filePath: string, extensionVersion: string, configFilePath: string | null) => {
+const getDockerRunParams = (filePath: string, extensionVersion: string, configFilePath: string | null, checkovVersion: string | undefined) => {
+    const image = checkovVersion ? `bridgecrew/checkov:${checkovVersion}` : 'bridgecrew/checkov';
     return configFilePath ?
         ['run', '--rm', '--tty', '--env', 'BC_SOURCE=vscode', '--env', `BC_SOURCE_VERSION=${extensionVersion}`,
-            '-v', `"${path.dirname(filePath)}:${dockerMountDir}"`, '-v', `"${path.dirname(configFilePath)}:${configMountDir}"`, 'bridgecrew/checkov',
+            '-v', `"${path.dirname(filePath)}:${dockerMountDir}"`, '-v', `"${path.dirname(configFilePath)}:${configMountDir}"`, image,
             '--config-file', `${configMountDir}/${path.basename(configFilePath)}`] :
         ['run', '--rm', '--tty', '--env', 'BC_SOURCE=vscode', '--env', `BC_SOURCE_VERSION=${extensionVersion}`,
-            '-v', `"${path.dirname(filePath)}:${dockerMountDir}"`, 'bridgecrew/checkov'];
+            '-v', `"${path.dirname(filePath)}:${dockerMountDir}"`, image];
 };
 
 const getpipRunParams = (configFilePath: string | null) => {
@@ -59,14 +60,18 @@ export const runCheckovScan = (logger: Logger, checkovInstallation: CheckovInsta
     return new Promise((resolve, reject) => {   
         const { checkovInstallationMethod, checkovPath, workingDir } = checkovInstallation;
 
-        const dockerRunParams = checkovInstallationMethod === 'docker' ? getDockerRunParams(fileName, extensionVersion, configPath) : [];
+        const dockerRunParams = checkovInstallationMethod === 'docker' ? getDockerRunParams(fileName, extensionVersion, configPath, checkovInstallation.version) : [];
         const pipRunParams =  ['pipenv', 'pip3'].includes(checkovInstallationMethod) ? getpipRunParams(configPath) : [];
         const filePath = checkovInstallationMethod === 'docker' ? convertToUnixPath(path.join(dockerMountDir, path.basename(fileName))) : fileName;
         const certificateParams: string[] = certPath ? ['-ca', certPath] : [];
         const bcIdParam: string[] = useBcIds ? ['--output-bc-ids'] : [];
         const checkovArguments: string[] = [...dockerRunParams, ...certificateParams, ...bcIdParam, '-s', '--bc-api-key', token, '--repo-id', 
             'vscode/extension', '-f', `"${filePath}"`, '-o', 'json', ...pipRunParams];
-        logger.info('Running checkov', { executablePath: checkovPath, arguments: checkovArguments.map(argument => argument === token ? '****' : argument) });
+        logger.info('Running checkov:');
+        logger.info(`${checkovPath} ${checkovArguments.map(argument => argument === token ? '****' : argument).join(' ')}`);
+        
+        runVersionCommand(logger, checkovPath, checkovInstallation.workingDir);
+        
         const ckv = spawn(checkovPath, checkovArguments,
             {
                 shell: true,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -4,3 +4,4 @@ export const REMOVE_DIAGNOSTICS_COMMAND = 'checkov.remove-diagnostics';
 export const OPEN_CONFIGURATION_COMMAND = 'checkov.configuration.open';
 export const INSTALL_OR_UPDATE_CHECKOV_COMMAND = 'checkov.install-or-update-checkov';
 export const GET_INSTALLATION_DETAILS_COMMAND = 'checkov.about-checkov';
+export const OPEN_CHECKOV_LOG = 'checkov.open-log';

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,3 +3,4 @@ export const RUN_FILE_SCAN_COMMAND = 'checkov.scan-file';
 export const REMOVE_DIAGNOSTICS_COMMAND = 'checkov.remove-diagnostics';
 export const OPEN_CONFIGURATION_COMMAND = 'checkov.configuration.open';
 export const INSTALL_OR_UPDATE_CHECKOV_COMMAND = 'checkov.install-or-update-checkov';
+export const GET_INSTALLATION_DETAILS_COMMAND = 'checkov.about-checkov';

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -26,3 +26,28 @@ export const getUseBcIds = (): boolean | undefined => {
     const useBcIds = configuration.get<boolean>('useBridgecrewIDs', false);
     return useBcIds;
 };
+
+export const getAutoUpdate = (): boolean => {
+    const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov');
+    const autoUpdate = configuration.get<boolean>('autoUpdateCheckov', false);
+    return autoUpdate;
+};
+
+export const getCheckovVersion = (): string | undefined => {
+    // do some normalization: trim, remove a leading 'v', return null instead of empty string
+    // e.g., 'v2.0.123' => '2.0.123'; '' => null; ' ' => null
+
+    const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov');
+    let checkovVersion = configuration.get<string | undefined>('checkovVersion', undefined);
+
+    if (!checkovVersion || !checkovVersion.trim()) {
+        return undefined;
+    }
+
+    checkovVersion = checkovVersion.trim();
+    if (checkovVersion.startsWith('v')) {
+        checkovVersion = checkovVersion.substring(1);
+    }
+
+    return checkovVersion;
+};

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -35,8 +35,8 @@ export const getCheckovVersion = (): string => {
     const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov');
     const checkovVersion = configuration.get<string>('checkovVersion', 'latest').trim().toLowerCase();
 
-    if (checkovVersion === 'latest') {
-        return checkovVersion;
+    if (checkovVersion === '' || checkovVersion === 'latest') {
+        return 'latest';
     } else {
         if (!semver.valid(checkovVersion)) {
             throw Error(`Invalid checkov version: ${checkovVersion}`);

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -30,13 +30,7 @@ export const getUseBcIds = (): boolean | undefined => {
     return useBcIds;
 };
 
-export const getAutoUpdate = (): boolean => {
-    const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov');
-    const autoUpdate = configuration.get<boolean>('autoUpdateCheckov', false);
-    return autoUpdate;
-};
-
-export const getCheckovVersion = (): string | undefined => {
+export const getCheckovVersion = (): string => {
 
     const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov');
     const checkovVersion = configuration.get<string>('checkovVersion', 'latest').trim().toLowerCase();

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -2,10 +2,11 @@ import * as vscode from 'vscode';
 import { Logger } from 'winston';
 import { setMissingConfigurationStatusBarItem } from './userInterface';
 import * as semver from 'semver';
+import { CheckovInstallation } from './checkovInstaller';
 
 const minCheckovVersion = '2.0.0';
 
-export const assureTokenSet = (logger: Logger, openConfigurationCommand: string): string | undefined => {
+export const assureTokenSet = (logger: Logger, openConfigurationCommand: string, checkovInstallation: CheckovInstallation | null): string | undefined => {
     // Read configuration
     const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov');
     const token = configuration.get<string>('token');
@@ -13,7 +14,7 @@ export const assureTokenSet = (logger: Logger, openConfigurationCommand: string)
         logger.error('Bridgecrew API token was not found. Please add it to the configuration.');
         vscode.window.showErrorMessage('Bridgecrew API token was not found. Please add it to the configuration in order to scan your code.', 'Open configuration')
             .then(choice => choice === 'Open configuration' && vscode.commands.executeCommand(openConfigurationCommand));
-        setMissingConfigurationStatusBarItem();
+        setMissingConfigurationStatusBarItem(checkovInstallation?.version);
     }
     return token;
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import { CheckovInstallation, installOrUpdateCheckov } from './checkovInstaller'
 import { runCheckovScan } from './checkovRunner';
 import { applyDiagnostics } from './diagnostics';
 import { fixCodeActionProvider, providedCodeActionKinds } from './suggestFix';
-import { getLogger, saveCheckovResult, isSupportedFileType, extensionVersion } from './utils';
+import { getLogger, saveCheckovResult, isSupportedFileType, extensionVersion, runVersionCommand } from './utils';
 import { initializeStatusBarItem, setErrorStatusBarItem, setPassedStatusBarItem, setReadyStatusBarItem, setSyncingStatusBarItem, showContactUsDetails } from './userInterface';
 import { assureTokenSet, getPathToCert, getUseBcIds } from './configuration';
 import { INSTALL_OR_UPDATE_CHECKOV_COMMAND, OPEN_CONFIGURATION_COMMAND, OPEN_EXTERNAL_COMMAND, REMOVE_DIAGNOSTICS_COMMAND, RUN_FILE_SCAN_COMMAND } from './commands';
@@ -44,7 +44,8 @@ export function activate(context: vscode.ExtensionContext): void {
                 extensionReady = false;
                 setSyncingStatusBarItem('Updating Checkov');
                 checkovInstallation = await installOrUpdateCheckov(logger, checkovInstallationDir);
-                logger.info(`Finished installing Checkov with ${checkovInstallation.checkovInstallationMethod}.` , { checkovPath: checkovInstallation.checkovPath });
+                logger.info('Checkov installation: ', checkovInstallation);
+                runVersionCommand(logger, checkovInstallation.checkovPath, checkovInstallation.workingDir);
                 setReadyStatusBarItem();
                 extensionReady = true;
                 if (vscode.window.activeTextEditor && isSupportedFileType(vscode.window.activeTextEditor.document.fileName))

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import { fixCodeActionProvider, providedCodeActionKinds } from './suggestFix';
 import { getLogger, saveCheckovResult, isSupportedFileType, extensionVersion, runVersionCommand } from './utils';
 import { initializeStatusBarItem, setErrorStatusBarItem, setPassedStatusBarItem, setReadyStatusBarItem, setSyncingStatusBarItem, showAboutCheckovMessage, showContactUsDetails } from './userInterface';
 import { assureTokenSet, getCheckovVersion, getPathToCert, getUseBcIds } from './configuration';
-import { GET_INSTALLATION_DETAILS_COMMAND, INSTALL_OR_UPDATE_CHECKOV_COMMAND, OPEN_CONFIGURATION_COMMAND, OPEN_EXTERNAL_COMMAND, REMOVE_DIAGNOSTICS_COMMAND, RUN_FILE_SCAN_COMMAND } from './commands';
+import { GET_INSTALLATION_DETAILS_COMMAND, INSTALL_OR_UPDATE_CHECKOV_COMMAND, OPEN_CHECKOV_LOG, OPEN_CONFIGURATION_COMMAND, OPEN_EXTERNAL_COMMAND, REMOVE_DIAGNOSTICS_COMMAND, RUN_FILE_SCAN_COMMAND } from './commands';
 import { getConfigFilePath } from './parseCheckovConfig';
 
 export const CHECKOV_MAP = 'checkovMap';
@@ -92,6 +92,9 @@ export function activate(context: vscode.ExtensionContext): void {
                 await showAboutCheckovMessage(checkovInstallation.version, checkovInstallation.checkovInstallationMethod);
             }
         }),
+        vscode.commands.registerCommand(OPEN_CHECKOV_LOG, async () => {
+            vscode.window.showTextDocument(vscode.Uri.joinPath(context.logUri, logFileName));
+        })
     );
 
     vscode.commands.executeCommand(INSTALL_OR_UPDATE_CHECKOV_COMMAND);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,7 +51,7 @@ export function activate(context: vscode.ExtensionContext): void {
                     vscode.commands.executeCommand(RUN_FILE_SCAN_COMMAND);
             } catch(error) {
                 setErrorStatusBarItem();
-                logger.error('Error occurred while preparing Checkov. try to reload vscode.', { error });
+                logger.error('Error occurred while preparing Checkov. Verify your settings, or try to reload vscode.', { error });
                 showContactUsDetails(context.logUri, logFileName);
             }
         }),

--- a/src/suggestFix.ts
+++ b/src/suggestFix.ts
@@ -5,7 +5,7 @@ import { DiagnosticReferenceCode } from './diagnostics';
 import { CHECKOV_MAP } from './extension';
 import { createDiagnosticKey } from './utils';
 
-const provideFixCodeActions = (workspaceState: vscode.Memento) => (document: vscode.TextDocument, range: vscode.Range | vscode.Selection, context: vscode.CodeActionContext, token: vscode.CancellationToken): vscode.CodeAction[] => {
+const provideFixCodeActions = (workspaceState: vscode.Memento) => (document: vscode.TextDocument, range: vscode.Range | vscode.Selection, context: vscode.CodeActionContext): vscode.CodeAction[] => {
     // for each diagnostic entry that has the matching `code`, create a code action command
     const checkovMap = workspaceState.get<Record<string, FailedCheckovCheck>>(CHECKOV_MAP) || {};
     return context.diagnostics

--- a/src/userInterface.ts
+++ b/src/userInterface.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { extensionVersion } from './utils';
 
 export const showContactUsDetails = (logDirectoryPath: vscode.Uri, logFileName: string): void => {
     const contactUsMessage = `
@@ -31,6 +32,11 @@ export const showUnsupportedFileMessage = (): void => {
     vscode.window.showWarningMessage(message);
 };
 
+export const showAboutCheckovMessage = async (version: string, installationMethod: string): Promise<void> => {
+    const message = `Checkov CLI version: ${version}; Installation method: ${installationMethod}; Extension version: ${extensionVersion}`;
+    vscode.window.showInformationMessage(message);
+};
+
 export const statusBarItem: vscode.StatusBarItem = vscode.window.createStatusBarItem();
 
 export const initializeStatusBarItem = (onClickCommand: string): void  => {
@@ -39,8 +45,8 @@ export const initializeStatusBarItem = (onClickCommand: string): void  => {
     statusBarItem.show();
 };
 
-export const setReadyStatusBarItem = (): void => {
-    statusBarItem.text = '$(gear) Checkov';
+export const setReadyStatusBarItem = (version: string | undefined): void => {
+    statusBarItem.text = version ? `$(gear) Checkov - v${version}` : '$(gear) Checkov';
 };
 
 export const setMissingConfigurationStatusBarItem = (): void => {

--- a/src/userInterface.ts
+++ b/src/userInterface.ts
@@ -40,21 +40,25 @@ export const initializeStatusBarItem = (onClickCommand: string): void  => {
 };
 
 export const setReadyStatusBarItem = (version: string | undefined): void => {
-    statusBarItem.text = version ? `$(gear) Checkov - v${version}` : '$(gear) Checkov';
+    statusBarItem.text = getStatusBarText('gear', version);
 };
 
-export const setMissingConfigurationStatusBarItem = (): void => {
-    statusBarItem.text = '$(exclude) Checkov';
+export const setMissingConfigurationStatusBarItem = (version: string | undefined): void => {
+    statusBarItem.text = getStatusBarText('exclude', version);
 };
 
-export const setSyncingStatusBarItem = (text = 'Checkov'): void => {
-    statusBarItem.text = `$(sync~spin) ${text}`;
+export const setSyncingStatusBarItem = (version: string | undefined, text = 'Checkov'): void => {
+    statusBarItem.text = getStatusBarText('sync~spin', version, text);
 };
 
-export const setErrorStatusBarItem = (): void => {
-    statusBarItem.text = '$(error) Checkov';
+export const setErrorStatusBarItem = (version: string | undefined): void => {
+    statusBarItem.text = getStatusBarText('error', version);
 };
 
-export const setPassedStatusBarItem = (): void => {
-    statusBarItem.text = '$(pass) Checkov';
+export const setPassedStatusBarItem = (version: string | undefined): void => {
+    statusBarItem.text = getStatusBarText('pass', version);
+};
+
+const getStatusBarText = (icon: string | undefined, version: string | undefined, text = 'Checkov'): string => {
+    return `${icon ? `$(${icon}) ` : ''}${text}${version ? ` - v${version}` : ''}`;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { exec, ExecOptions } from 'child_process';
+import { exec, ExecOptions, spawn } from 'child_process';
 import winston from 'winston';
 import { FailedCheckovCheck } from './checkovRunner';
 import { DiagnosticReferenceCode } from './diagnostics';
@@ -83,3 +83,12 @@ export const getWorkspacePath = (logger: winston.Logger): string | void => {
     return;
 };
 
+export const runVersionCommand = (logger: winston.Logger, checkovPath: string, workingDir: string | undefined): void => {
+    const versionCmd = spawn(checkovPath, ['-v'], { shell: true, cwd: workingDir });
+    versionCmd.stdout.on('data', data => {
+        logger.info(`checkov version: ${data}`);
+    });
+    versionCmd.stderr.on('data', data => {
+        logger.warn(`Got stderr output when testing checkov version: ${data}`);
+    });
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { exec, ExecOptions, spawn } from 'child_process';
+import { exec, ExecOptions } from 'child_process';
 import winston from 'winston';
 import { FailedCheckovCheck } from './checkovRunner';
 import { DiagnosticReferenceCode } from './diagnostics';
@@ -83,12 +83,10 @@ export const getWorkspacePath = (logger: winston.Logger): string | void => {
     return;
 };
 
-export const runVersionCommand = (logger: winston.Logger, checkovPath: string, workingDir: string | undefined): void => {
-    const versionCmd = spawn(checkovPath, ['-v'], { shell: true, cwd: workingDir });
-    versionCmd.stdout.on('data', data => {
-        logger.info(`checkov version: ${data}`);
-    });
-    versionCmd.stderr.on('data', data => {
-        logger.warn(`Got stderr output when testing checkov version: ${data}`);
-    });
+export const runVersionCommand = async (logger: winston.Logger, checkovPath: string, checkovVersion: string | undefined, workingDir: string | undefined): Promise<string> => {
+    const command = checkovPath === 'docker' ? `docker run bridgecrew/checkov:${checkovVersion} -v` : `${checkovPath} -v`;
+    logger.debug(`Version command: ${command}`);
+    const resp = await asyncExec(command, { ...(workingDir ? { cwd: workingDir } : {}) });
+    logger.debug(`Response from version command: ${resp[0]}`);
+    return resp[0].trim();
 };


### PR DESCRIPTION
# In This PR

- Adds "checkov version" setting, allowing users to specify a specific version to use (>= 2.0.0) or 'latest' (default)
- Adds an "about checkov" command to view the checkov installation details
- Adds a command to open the checkov log

(Edited)

## Pictures/videos

- [X] I've reviewed my own code
