### PR TITLE
pull the repo name from git if it exists

### DIFF
--- a/src/checkovInstaller.ts
+++ b/src/checkovInstaller.ts
@@ -41,12 +41,17 @@ const installOrUpdateCheckovWithPipenv = async (logger: Logger, installationDir:
 
     try {
         fs.mkdirSync(installationDir, { recursive: true });
+        logger.debug(`Installation dir: ${installationDir}`);
+        const installCommand = `pipenv --python 3 install checkov${checkovVersion && checkovVersion.toLowerCase() !== 'latest' ? `==${checkovVersion}` : '~=2.0.0'}`;
+        logger.debug(`Testing pipenv installation with command: ${installCommand}`);
+        await asyncExec(installCommand, { cwd: installationDir });
 
-        const command = `pipenv --python 3 install checkov${checkovVersion ? `==${checkovVersion}` : '~=2.0.0'}`;
-        logger.debug('Testing pipenv installation with command: ', command);
-        await asyncExec(command, { cwd: installationDir });
+        const getExeCommand = 'pipenv run which python';
+        logger.debug(`Getting pipenv executable with command: ${getExeCommand}`);
+        const execOutput = await asyncExec(getExeCommand, { cwd: installationDir });
+        logger.debug(`pipenv python executable: ${execOutput[0]}`);
 
-        const checkovPath = 'pipenv run checkov';
+        const checkovPath = `"${path.join(path.dirname(execOutput[0]), 'checkov')}"`;
         logger.info('Checkov installed successfully using pipenv.', { checkovPath, installationDir });
         return checkovPath;
     } catch (error) {
@@ -76,17 +81,16 @@ type CheckovInstallationMethod = 'pip3' | 'pipenv' | 'docker';
 export interface CheckovInstallation {
     checkovInstallationMethod: CheckovInstallationMethod;
     checkovPath: string;
-    workingDir?: string;
     version?: string;
 }
 
 export const installOrUpdateCheckov = async (logger: Logger, installationDir: string, checkovVersion: string): Promise<CheckovInstallation> => {
-    // const dockerCheckovPath = await installOrUpdateCheckovWithDocker(logger, checkovVersion);
-    // if (dockerCheckovPath) return { checkovInstallationMethod: 'docker' , checkovPath: dockerCheckovPath };
+    const dockerCheckovPath = await installOrUpdateCheckovWithDocker(logger, checkovVersion);
+    if (dockerCheckovPath) return { checkovInstallationMethod: 'docker' , checkovPath: dockerCheckovPath };
     const pip3CheckovPath = await installOrUpdateCheckovWithPip3(logger, checkovVersion);
     if (pip3CheckovPath) return { checkovInstallationMethod: 'pip3' , checkovPath: pip3CheckovPath };
-    const pipenvCheckovPath = await installOrUpdateCheckovWithPipenv(logger, installationDir, checkovVersion);
-    if (pipenvCheckovPath) return { checkovInstallationMethod: 'pipenv' , checkovPath: pipenvCheckovPath, workingDir: installationDir };
+    const pipenvCheckovPath =await installOrUpdateCheckovWithPipenv(logger, installationDir, checkovVersion);
+    if (pipenvCheckovPath) return { checkovInstallationMethod: 'pipenv' , checkovPath: pipenvCheckovPath };
 
     throw new Error('Could not install Checkov.');
 };

--- a/src/checkovInstaller.ts
+++ b/src/checkovInstaller.ts
@@ -81,8 +81,8 @@ export interface CheckovInstallation {
 }
 
 export const installOrUpdateCheckov = async (logger: Logger, installationDir: string, checkovVersion: string): Promise<CheckovInstallation> => {
-    const dockerCheckovPath = await installOrUpdateCheckovWithDocker(logger, checkovVersion);
-    if (dockerCheckovPath) return { checkovInstallationMethod: 'docker' , checkovPath: dockerCheckovPath };
+    // const dockerCheckovPath = await installOrUpdateCheckovWithDocker(logger, checkovVersion);
+    // if (dockerCheckovPath) return { checkovInstallationMethod: 'docker' , checkovPath: dockerCheckovPath };
     const pip3CheckovPath = await installOrUpdateCheckovWithPip3(logger, checkovVersion);
     if (pip3CheckovPath) return { checkovInstallationMethod: 'pip3' , checkovPath: pip3CheckovPath };
     const pipenvCheckovPath = await installOrUpdateCheckovWithPipenv(logger, installationDir, checkovVersion);

--- a/src/checkovInstaller.ts
+++ b/src/checkovInstaller.ts
@@ -89,7 +89,7 @@ export const installOrUpdateCheckov = async (logger: Logger, installationDir: st
     if (dockerCheckovPath) return { checkovInstallationMethod: 'docker' , checkovPath: dockerCheckovPath };
     const pip3CheckovPath = await installOrUpdateCheckovWithPip3(logger, checkovVersion);
     if (pip3CheckovPath) return { checkovInstallationMethod: 'pip3' , checkovPath: pip3CheckovPath };
-    const pipenvCheckovPath =await installOrUpdateCheckovWithPipenv(logger, installationDir, checkovVersion);
+    const pipenvCheckovPath = await installOrUpdateCheckovWithPipenv(logger, installationDir, checkovVersion);
     if (pipenvCheckovPath) return { checkovInstallationMethod: 'pipenv' , checkovPath: pipenvCheckovPath };
 
     throw new Error('Could not install Checkov.');

--- a/src/checkovRunner.ts
+++ b/src/checkovRunner.ts
@@ -42,7 +42,7 @@ const configMountDir = '/checkovConfig';
 const getDockerRunParams = (filePath: string, extensionVersion: string, configFilePath: string | null, checkovVersion: string | undefined) => {
     const image = `bridgecrew/checkov:${checkovVersion}`;
     const params = ['run', '--rm', '--tty', '--env', 'BC_SOURCE=vscode', '--env', `BC_SOURCE_VERSION=${extensionVersion}`,
-        '-v', `"${path.dirname(filePath)}:${dockerMountDir}"`];
+        '-v', `"${path.dirname(filePath)}:${dockerMountDir}"`, '-w', dockerMountDir];
     
     return configFilePath ?
         [...params, '-v', `"${path.dirname(configFilePath)}:${configMountDir}"`, image, 

--- a/src/checkovRunner.ts
+++ b/src/checkovRunner.ts
@@ -3,7 +3,7 @@ import { spawn } from 'child_process';
 import * as path from 'path';
 import { Logger } from 'winston';
 import { CheckovInstallation } from './checkovInstaller';
-import { convertToUnixPath, getGitRepoName, getDockerPathParams, isChildPath, runVersionCommand } from './utils';
+import { convertToUnixPath, getGitRepoName, getDockerPathParams, runVersionCommand } from './utils';
 
 export interface FailedCheckovCheck {
     checkId: string;

--- a/src/checkovRunner.ts
+++ b/src/checkovRunner.ts
@@ -71,6 +71,7 @@ export const runCheckovScan = (logger: Logger, checkovInstallation: CheckovInsta
         const filePathParams = checkovInstallationMethod === 'docker' ? [] : ['-f', fileName];
         const certificateParams: string[] = certPath ? ['-ca', certPath] : [];
         const bcIdParam: string[] = useBcIds ? ['--output-bc-ids'] : [];
+        const workingDir2 = vscode.workspace.rootPath;
         getGitRepoName(logger, vscode.window.activeTextEditor?.document.fileName).then((repoName) => {
             const checkovArguments: string[] = [...dockerRunParams, ...certificateParams, ...bcIdParam, '-s', '--bc-api-key', token, '--repo-id', 
                 repoName, ...filePathParams, '-o', 'json', ...pipRunParams];
@@ -83,7 +84,7 @@ export const runCheckovScan = (logger: Logger, checkovInstallation: CheckovInsta
                 {
                     shell: true,
                     env: { ...process.env, BC_SOURCE: 'vscode', BC_SOURCE_VERSION: extensionVersion },
-                    ...(workingDir ? { cwd: workingDir } : {})
+                    ...(workingDir2 ? { cwd: workingDir2 } : {})
                 });
 
             let stdout = '';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,7 +46,7 @@ export function activate(context: vscode.ExtensionContext): void {
                 const checkovVersion = getCheckovVersion();
                 checkovInstallation = await installOrUpdateCheckov(logger, checkovInstallationDir, checkovVersion);
                 logger.info('Checkov installation: ', checkovInstallation);
-                checkovInstallation.version = await runVersionCommand(logger, checkovInstallation.checkovPath, checkovVersion, checkovInstallation.workingDir);
+                checkovInstallation.version = await runVersionCommand(logger, checkovInstallation.checkovPath, checkovVersion);
                 setReadyStatusBarItem(checkovInstallation.version);
                 extensionReady = true;
                 if (vscode.window.activeTextEditor && isSupportedFileType(vscode.window.activeTextEditor.document.fileName))

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -147,6 +147,20 @@ export const getGitRepoName = async (logger: winston.Logger, filename: string | 
     return defaultRepoName;
 };
 
+export const getDockerPathParams = (workspaceRoot: string | undefined, filePath: string): [string | null, string] => {
+    if (!workspaceRoot) {
+        return [null, filePath];
+    }
+    const relative = path.relative(workspaceRoot, filePath);
+    return relative.length > 0 && !relative.startsWith('../') && !path.isAbsolute(relative) ? [workspaceRoot, relative] : [null, filePath];
+};
+
+export const isChildPath = (parent: string, pathToCheck: string): boolean => {
+    const relative = path.relative(parent, pathToCheck);
+    // the absolute check handles changes between drives / mounts
+    return relative.length > 0 && !relative.startsWith('../') && !path.isAbsolute(relative);
+};
+
 const parseRepoName = (repoUrl: string): string | null => {
     const result = repoUrlRegex.exec(repoUrl);
     return result ? result[4] : null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -155,12 +155,6 @@ export const getDockerPathParams = (workspaceRoot: string | undefined, filePath:
     return relative.length > 0 && !relative.startsWith('../') && !path.isAbsolute(relative) ? [workspaceRoot, relative] : [null, filePath];
 };
 
-export const isChildPath = (parent: string, pathToCheck: string): boolean => {
-    const relative = path.relative(parent, pathToCheck);
-    // the absolute check handles changes between drives / mounts
-    return relative.length > 0 && !relative.startsWith('../') && !path.isAbsolute(relative);
-};
-
 const parseRepoName = (repoUrl: string): string | null => {
     const result = repoUrlRegex.exec(repoUrl);
     return result ? result[4] : null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,10 +91,10 @@ export const getWorkspacePath = (logger: winston.Logger): string | void => {
     return;
 };
 
-export const runVersionCommand = async (logger: winston.Logger, checkovPath: string, checkovVersion: string | undefined, workingDir: string | undefined): Promise<string> => {
+export const runVersionCommand = async (logger: winston.Logger, checkovPath: string, checkovVersion: string | undefined): Promise<string> => {
     const command = checkovPath === 'docker' ? `docker run bridgecrew/checkov:${checkovVersion} -v` : `${checkovPath} -v`;
     logger.debug(`Version command: ${command}`);
-    const resp = await asyncExec(command, { ...(workingDir ? { cwd: workingDir } : {}) });
+    const resp = await asyncExec(command);
     logger.debug(`Response from version command: ${resp[0]}`);
     return resp[0].trim();
 };


### PR DESCRIPTION
# In This PR

- Updates each runner method (docker, pip, pipenv) to run from the workspace root and pass the relative file path to the runner
- runs `git remote -v` and tries to parse the output to determine the repo ID (this allows VSCode to honor platform suppressions)

Collectively, these two changes allow VSCode to match suppressions defined in the platform.

## Pictures/videos

- [X] I've reviewed my own code
