### PR TITLE
fix windows path and installation method issues

### DIFF
--- a/src/checkovInstaller.ts
+++ b/src/checkovInstaller.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { Logger, loggers } from 'winston';
+import { Logger } from 'winston';
 import { asyncExec, isWindows } from './utils';
 
 const isPipCheckovInstalledGlobally = async () => {
@@ -30,7 +30,7 @@ const getPipCheckovExecutablePath = async (logger: Logger): Promise<string> => {
         }
     }
 
-    throw new Error('Failed to find the path to the non-global checkov executable')
+    throw new Error('Failed to find the path to the non-global checkov executable');
 };
 
 const installOrUpdateCheckovWithPip3 = async (logger: Logger, checkovVersion: string): Promise<string | null> => {

--- a/src/checkovRunner.ts
+++ b/src/checkovRunner.ts
@@ -45,13 +45,13 @@ const getDockerRunParams = (workspaceRoot: string | undefined, filePath: string,
     // if filepath is within the workspace, then the mount root will be the workspace path, and the file path will be the relative file path from there.
     // otherwise, we will mount into the file's directory, and the file path is just the filename.
     const mountRoot = pathParams[0] || path.dirname(pathParams[1]);
-    const filePathToScan = pathParams[0] ? pathParams[1] : path.basename(filePath);
+    const filePathToScan = convertToUnixPath(pathParams[0] ? pathParams[1] : path.basename(filePath));
     const params = ['run', '--rm', '--tty', '--env', 'BC_SOURCE=vscode', '--env', `BC_SOURCE_VERSION=${extensionVersion}`,
         '-v', `"${mountRoot}:${dockerMountDir}"`, '-w', dockerMountDir];
     
     return configFilePath ?
         [...params, '-v', `"${path.dirname(configFilePath)}:${configMountDir}"`, image, 
-            '--config-file', `${configMountDir}/${path.basename(configFilePath)}`, '-f', convertToUnixPath(filePathToScan)] :
+            '--config-file', `${configMountDir}/${path.basename(configFilePath)}`, '-f', filePathToScan] :
         [...params, image, '-f', filePathToScan];
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,6 +16,7 @@ const defaultRepoName = 'vscode/extension';
 // https://github.com/org/repo.git
 // eslint-disable-next-line no-useless-escape
 const repoUrlRegex = /^(https|git)(:\/\/|@)([^\/:]+)[\/:](.+).git$/;
+export const isWindows = process.platform === 'win32';
 
 type ExecOutput = [stdout: string, stderr: string];
 export const asyncExec = async (commandToExecute: string, options: ExecOptions = {}): Promise<ExecOutput> => {
@@ -152,7 +153,7 @@ export const getDockerPathParams = (workspaceRoot: string | undefined, filePath:
         return [null, filePath];
     }
     const relative = path.relative(workspaceRoot, filePath);
-    return relative.length > 0 && !relative.startsWith('../') && !path.isAbsolute(relative) ? [workspaceRoot, relative] : [null, filePath];
+    return relative.length > 0 && !relative.startsWith('../') && !relative.startsWith('..\\') && !path.isAbsolute(relative) ? [workspaceRoot, relative] : [null, filePath];
 };
 
 const parseRepoName = (repoUrl: string): string | null => {


### PR DESCRIPTION
# In This PR

- Fixes an issue introduced by https://github.com/bridgecrewio/checkov-vscode/pull/60 where the docker file argument was not properly converted to a windows path
- Fixes pipenv and pip installation methods on Windows, which did not seem to work with a --user installation

## Pictures/videos

- [X] I've reviewed my own code
