### PR TITLE
Temp repo id fix

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,10 @@ const defaultRepoName = 'vscode/extension';
 // git@github.com:org/repo.git
 // https://github.com/org/repo.git
 // eslint-disable-next-line no-useless-escape
-const repoUrlRegex = /^(https|git)(:\/\/|@)([^\/:]+)[\/:](.+).git$/;
+
+// See comment in "parseRepoName"
+// const repoUrlRegex = /^(https|git)(:\/\/|@)([^\/:]+)[\/:](.+).git$/;
+
 export const isWindows = process.platform === 'win32';
 
 type ExecOutput = [stdout: string, stderr: string];
@@ -157,6 +160,22 @@ export const getDockerPathParams = (workspaceRoot: string | undefined, filePath:
 };
 
 const parseRepoName = (repoUrl: string): string | null => {
-    const result = repoUrlRegex.exec(repoUrl);
-    return result ? result[4] : null;
+    const lastSlash = repoUrl.lastIndexOf('/');
+    if (lastSlash === -1) {
+        return null;
+    }
+    // / is used in https URLs, and : in git@ URLs
+    const priorSlash = repoUrl.lastIndexOf('/', lastSlash - 1);
+    const priorColon = repoUrl.lastIndexOf(':', lastSlash - 1);
+
+    if (priorSlash === -1 && priorColon === -1) {
+        return null;
+    }
+
+    return repoUrl.substring(Math.max(priorSlash, priorColon) + 1, repoUrl.lastIndexOf('.git'));
+
+    // Commenting out for now, because the code above is a temporary workaround to the case where the git server
+    // is not hosted at the root level (e.g., https://company.example.com/git)
+    // const result = repoUrlRegex.exec(repoUrl);
+    // return result ? result[4] : null;
 };


### PR DESCRIPTION
# In This PR

- This is a temporary workaround to correctly set the `--repo-id` parameter in the case where the git server is not hosted at the root level (e.g., `https://company.example.com/git`). This would result in the repo ID being passed as `git/owner/repo`, which is both incorrect from the repo standpoint, and also (currently) not supported in [Checkov](https://github.com/bridgecrewio/checkov/issues/1559).

There will need to be a future workaround to handle these types of URLs as well as repo names with multiple slashes in them, which is a feature supported by Gitlab.

## Pictures/videos

- [X] I've reviewed my own code
