### PR TITLE
fix: wrap -f with quotes

### DIFF
--- a/src/checkovRunner.ts
+++ b/src/checkovRunner.ts
@@ -51,8 +51,8 @@ const getDockerRunParams = (workspaceRoot: string | undefined, filePath: string,
     
     return configFilePath ?
         [...params, '-v', `"${path.dirname(configFilePath)}:${configMountDir}"`, image, 
-            '--config-file', `${configMountDir}/${path.basename(configFilePath)}`, '-f', filePathToScan] :
-        [...params, image, '-f', filePathToScan];
+            '--config-file', `${configMountDir}/${path.basename(configFilePath)}`, '-f', `"${filePathToScan}"`] :
+        [...params, image, '-f', `"filePathToScan"`];
 };
 
 const getpipRunParams = (configFilePath: string | null) => {
@@ -68,7 +68,7 @@ export const runCheckovScan = (logger: Logger, checkovInstallation: CheckovInsta
 
         const dockerRunParams = checkovInstallationMethod === 'docker' ? getDockerRunParams(vscode.workspace.rootPath, fileName, extensionVersion, configPath, checkovInstallation.version) : [];
         const pipRunParams =  ['pipenv', 'pip3'].includes(checkovInstallationMethod) ? getpipRunParams(configPath) : [];
-        const filePathParams = checkovInstallationMethod === 'docker' ? [] : ['-f', fileName];
+        const filePathParams = checkovInstallationMethod === 'docker' ? [] : ['-f', `"${fileName}"`];
         const certificateParams: string[] = certPath ? ['-ca', `"${certPath}"`] : [];
         const bcIdParam: string[] = useBcIds ? ['--output-bc-ids'] : [];
         const workingDir = vscode.workspace.rootPath;

--- a/src/checkovRunner.ts
+++ b/src/checkovRunner.ts
@@ -51,8 +51,8 @@ const getDockerRunParams = (workspaceRoot: string | undefined, filePath: string,
     
     return configFilePath ?
         [...params, '-v', `"${path.dirname(configFilePath)}:${configMountDir}"`, image, 
-            '--config-file', `${configMountDir}/${path.basename(configFilePath)}`, '-f', `"${filePathToScan}"`] :
-        [...params, image, '-f', `"filePathToScan"`];
+            '--config-file', `${configMountDir}/${path.basename(configFilePath)}`, '-f', filePathToScan] :
+        [...params, image, '-f', filePathToScan];
 };
 
 const getpipRunParams = (configFilePath: string | null) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,10 +79,10 @@ export const convertToUnixPath = (path: string): string => {
     const hasNonAscii = /[^\u0000-\u0080]+/.test(path);
 
     if (isExtendedLengthPath || hasNonAscii) {
-        return path;
+        return `"${path}"`;
     }
 
-    return path.replace(/\\/g, '/');
+    return `"${path.replace(/\\/g, '/')}"`;
 };
 
 export const getWorkspacePath = (logger: winston.Logger): string | void => {


### PR DESCRIPTION
# In This PR

- When running on windows without docker installed and having checkov installed via PIP if you had a space in the file path name e.g. C:\temp\demo project\template.yaml then the scan would fail due to the space. Changes made are to wrap the -f arguments with quotes to ensure the full path is taken into account.

Fixes #63 

- [x] I've reviewed my own code
