### PR TITLE
handle URLs not ending in .git

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -174,8 +174,8 @@ const parseRepoName = (repoUrl: string): string | null => {
         return null;
     }
 
-    const gitIndex = repoUrl.lastIndexOf('.git');
-    return repoUrl.substring(Math.max(priorSlash, priorColon) + 1, gitIndex == -1 ? repoUrl.length : gitIndex);
+    const endsWithDotGit = repoUrl.endsWith('.git');
+    return repoUrl.substring(Math.max(priorSlash, priorColon) + 1, endsWithDotGit ? repoUrl.length - 4 : repoUrl.length);
 
     // Commenting out for now, because the code above is a temporary workaround to the case where the git server
     // is not hosted at the root level (e.g., https://company.example.com/git)


### PR DESCRIPTION
# In This PR

- Fixes the repo parsing logic to handle remote URLs that do not end in .git, which should be rare, but apparently is possible

## Pictures/videos

- [X] I've reviewed my own code
