### PR TITLE
Fix(no resources scan): handle 0 scanned resources checkov response

### DIFF
--- a/src/checkovRunner.ts
+++ b/src/checkovRunner.ts
@@ -51,7 +51,7 @@ const getDockerRunParams = (workspaceRoot: string | undefined, filePath: string,
     // otherwise, we will mount into the file's directory, and the file path is just the filename.
     const mountRoot = pathParams[0] || path.dirname(pathParams[1]);
     const filePathToScan = convertToUnixPath(pathParams[0] ? pathParams[1] : path.basename(filePath));
-    const params = ['run', '--name', 'checkov-vscode', '--rm', '--tty', '--env', 'BC_SOURCE=vscode', '--env', `BC_SOURCE_VERSION=${extensionVersion}`,
+    const params = ['run', '--rm', '--tty', '--env', 'BC_SOURCE=vscode', '--env', `BC_SOURCE_VERSION=${extensionVersion}`,
         '-v', `"${mountRoot}:${dockerMountDir}"`, '-w', dockerMountDir];
     
     return configFilePath ?


### PR DESCRIPTION
# In This PR
- Handle error thrown after file scanned with no errors and resources

## Previous error
```
[debug]: Response from version command: 2.0.528
 
[debug]: Checkov scan process exited with code 0 
[debug]: Checkov task output: {"stdout":"{\n    \"passed\": 0,\n    \"failed\": 0,\n    \"skipped\": 0,\n    \"parsing_errors\": 0,\n    \"resource_count\": 0,\n    \"checkov_version\": \"2.0.528\"\n}\n"}
[error]: Failed to get response from Checkov. {"error":{"message":"Cannot read property 'failed_checks' of undefined","stack":"TypeError: Cannot read property 'failed_checks' of undefined\n\tat parseCheckovResponse (/Users/steve/.vscode/extensions/bridgecrew.checkov-1.0.51/out/checkovRunner.js:113:44)\n\tat ChildProcess.<anonymous> (/Users/steve/.vscode/extensions/bridgecrew.checkov-1.0.51/out/checkovRunner.js:93:29)\n\tat ChildProcess.emit (events.js:315:20)\n\tat maybeClose (internal/child_process.js:1048:16)\n\tat Process.ChildProcess._handle.onexit (internal/child_process.js:288:5)"}}
[error]: Error occurred while running a checkov scan {"error":"Failed to get response from Checkov."}
```
- [ ] I've reviewed my own code
