### PR TITLE
fix diagnostic creation for custom policies

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,8 +50,17 @@ export const saveCheckovResult = (state: vscode.Memento, checkovFails: FailedChe
     state.update(CHECKOV_MAP, checkovMap);
 };
 
-export const createDiagnosticKey = (diagnostic: vscode.Diagnostic): string =>
-    `${(diagnostic.code as DiagnosticReferenceCode).value}-${diagnostic.range.start.line + 1}`;
+export const createDiagnosticKey = (diagnostic: vscode.Diagnostic): string => {
+    let checkId;
+    if (typeof(diagnostic.code) === 'string') {
+        // code is a custom policy in format: policy_id[:guideline]
+        const colonIndex = diagnostic.code.indexOf(':');
+        checkId = colonIndex === -1 ? diagnostic.code : diagnostic.code.substring(0, colonIndex);
+    } else {
+        checkId = (diagnostic.code as DiagnosticReferenceCode).value;
+    }
+    return `${checkId}-${diagnostic.range.start.line + 1}`;
+};
 export const createCheckovKey = (checkovFail: FailedCheckovCheck): string => `${checkovFail.checkId}-${checkovFail.fileLineRange[0]}`;
 
 export const getLogger = (logFileDir: string, logFileName: string): winston.Logger => winston.createLogger({


### PR DESCRIPTION
# In This PR

- Fixes the logic to create "diagnostic" objects. It was not correctly looking up custom policies because of the way we display custom policy docs. The result was that any resource with custom policy violations had no quick fix actions available.

The cause was [here](https://github.com/bridgecrewio/checkov-vscode/blob/f4c9e078a876befa708291ae043c39a0ea18f8f9/src/diagnostics.ts#L20). 

`diagnostic.code` is a string for custom policies, so `diagnostic.code.value` returns undefined, which breaks the map lookup [here](https://github.com/bridgecrewio/checkov-vscode/blob/f4c9e078a876befa708291ae043c39a0ea18f8f9/src/suggestFix.ts#L12).

## Pictures/videos

- [X] I've reviewed my own code
