### PR TITLE
use python3 in version command and run during installation

### DIFF
--- a/src/checkovInstaller.ts
+++ b/src/checkovInstaller.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { Logger } from 'winston';
 import { asyncExec, isWindows } from './utils';
+import { verifyPythonVersion } from './configuration';
 
 const isPipCheckovInstalledGlobally = async () => {
     try {
@@ -37,6 +38,7 @@ const installOrUpdateCheckovWithPip3 = async (logger: Logger, checkovVersion: st
     logger.info('Trying to install Checkov using pip3.');
 
     try {
+        await verifyPythonVersion(logger);
         const command = `pip3 install --user -U -i https://pypi.org/simple/ checkov${checkovVersion === 'latest' ? '' : `==${checkovVersion}`}`;
         logger.debug(`Testing pip3 installation with command: ${command}`);
         await asyncExec(command);
@@ -75,6 +77,7 @@ const installOrUpdateCheckovWithPipenv = async (logger: Logger, installationDir:
         fs.mkdirSync(installationDir, { recursive: true });
         logger.debug(`Installation dir: ${installationDir}`);
         const installCommand = `pipenv --python 3 install checkov${checkovVersion && checkovVersion.toLowerCase() !== 'latest' ? `==${checkovVersion}` : '~=2.0.0'}`;
+        await verifyPythonVersion(logger, 'pipenv run python --version');
         logger.debug(`Testing pipenv installation with command: ${installCommand}`);
         await asyncExec(installCommand, { cwd: installationDir });
 

--- a/src/checkovRunner.ts
+++ b/src/checkovRunner.ts
@@ -72,7 +72,6 @@ export const runCheckovScan = (logger: Logger, checkovInstallation: CheckovInsta
     certPath: string | undefined, useBcIds: boolean | undefined, debugLogs: boolean | undefined, cancelToken: vscode.CancellationToken, configPath: string | null, checkovVersion: string, prismaUrl: string | undefined): Promise<CheckovResponse> => {
     return new Promise((resolve, reject) => {   
         const { checkovInstallationMethod, checkovPath } = checkovInstallation;
-
         const dockerRunParams = checkovInstallationMethod === 'docker' ? getDockerRunParams(vscode.workspace.rootPath, fileName, extensionVersion, configPath, checkovInstallation.version, prismaUrl, debugLogs) : [];
         const pipRunParams =  ['pipenv', 'pip3'].includes(checkovInstallationMethod) ? getpipRunParams(configPath) : [];
         const filePathParams = checkovInstallationMethod === 'docker' ? [] : ['-f', `"${fileName}"`];

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -71,8 +71,11 @@ export const getCheckovVersion = (): string => {
     }
 };
 
-export const verifyPythonVersion = async (logger: Logger): Promise<void> => {
-    const [pythonVersionResponse] = await asyncExec('python --version');
+export const verifyPythonVersion = async (logger: Logger, command = 'python3 --version'): Promise<void> => {
+    logger.debug(`Getting python version with command: ${command}`);
+    const [pythonVersionResponse] = await asyncExec(command);
+    logger.debug('Raw output:');
+    logger.debug(pythonVersionResponse);
     const pythonVersion = pythonVersionResponse.split(' ')[1];
     logger.debug(`Python version: ${pythonVersion}`);
     if (semver.lt(pythonVersion, minPythonVersion)){

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import { applyDiagnostics } from './diagnostics';
 import { fixCodeActionProvider, providedCodeActionKinds } from './suggestFix';
 import { getLogger, saveCheckovResult, isSupportedFileType, extensionVersion, runVersionCommand } from './utils';
 import { initializeStatusBarItem, setErrorStatusBarItem, setPassedStatusBarItem, setReadyStatusBarItem, setSyncingStatusBarItem, showAboutCheckovMessage, showContactUsDetails } from './userInterface';
-import { assureTokenSet, getCheckovVersion, shouldDisableErrorMessage, getPathToCert, getUseBcIds, getPrismaUrl, getUseDebugLogs, verifyPythonVersion } from './configuration';
+import { assureTokenSet, getCheckovVersion, shouldDisableErrorMessage, getPathToCert, getUseBcIds, getPrismaUrl, getUseDebugLogs } from './configuration';
 import { GET_INSTALLATION_DETAILS_COMMAND, INSTALL_OR_UPDATE_CHECKOV_COMMAND, OPEN_CHECKOV_LOG, OPEN_CONFIGURATION_COMMAND, OPEN_EXTERNAL_COMMAND, REMOVE_DIAGNOSTICS_COMMAND, RUN_FILE_SCAN_COMMAND } from './commands';
 import { getConfigFilePath } from './parseCheckovConfig';
 
@@ -43,7 +43,6 @@ export function activate(context: vscode.ExtensionContext): void {
             try {
                 extensionReady = false;
                 setSyncingStatusBarItem(checkovInstallation?.version, 'Updating Checkov');
-                await verifyPythonVersion(logger);
                 const checkovVersion = getCheckovVersion();
                 checkovInstallation = await installOrUpdateCheckov(logger, checkovInstallationDir, checkovVersion);
                 logger.info('Checkov installation: ', checkovInstallation);


### PR DESCRIPTION
# In This PR

- Fixes the new python version check, which used "python" (not "python3") and crashed for most users
- Also runs it during installation, so that it doesn't run during VSCode startup, and so it doesn't run if you are using docker

## Pictures/videos

- [X] I've reviewed my own code
