### PR TITLE
use a global checkov executable if available and all other installation options fail

### DIFF
--- a/src/checkovInstaller.ts
+++ b/src/checkovInstaller.ts
@@ -118,12 +118,22 @@ export interface CheckovInstallation {
 }
 
 export const installOrUpdateCheckov = async (logger: Logger, installationDir: string, checkovVersion: string): Promise<CheckovInstallation> => {
-    const dockerCheckovPath = await installOrUpdateCheckovWithDocker(logger, checkovVersion);
-    if (dockerCheckovPath) return { checkovInstallationMethod: 'docker' , checkovPath: dockerCheckovPath };
-    const pip3CheckovPath = await installOrUpdateCheckovWithPip3(logger, checkovVersion);
-    if (pip3CheckovPath) return { checkovInstallationMethod: 'pip3' , checkovPath: pip3CheckovPath };
-    const pipenvCheckovPath = await installOrUpdateCheckovWithPipenv(logger, installationDir, checkovVersion);
-    if (pipenvCheckovPath) return { checkovInstallationMethod: 'pipenv' , checkovPath: pipenvCheckovPath };
+    // const dockerCheckovPath = await installOrUpdateCheckovWithDocker(logger, checkovVersion);
+    // if (dockerCheckovPath) return { checkovInstallationMethod: 'docker' , checkovPath: dockerCheckovPath };
+    // const pip3CheckovPath = await installOrUpdateCheckovWithPip3(logger, checkovVersion);
+    // if (pip3CheckovPath) return { checkovInstallationMethod: 'pip3' , checkovPath: pip3CheckovPath };
+    // const pipenvCheckovPath = await installOrUpdateCheckovWithPipenv(logger, installationDir, checkovVersion);
+    // if (pipenvCheckovPath) return { checkovInstallationMethod: 'pipenv' , checkovPath: pipenvCheckovPath };
+
+    logger.warn('All installation / update methods failed; attempting to fall back to a global checkov installation');
+
+    if (await isPipCheckovInstalledGlobally()) {
+        logger.warn('Checkov appears to be installed globally, so it will be used. However, it may be an outdated version.');
+        // it could be installed manually via pip, brew, or something else. this return value will make it just use the `checkov` command.
+        return { checkovInstallationMethod: 'pip3' , checkovPath: 'checkov' };
+    } else {
+        logger.error('Could not find a global `checkov` executable either');
+    }
 
     throw new Error('Could not install Checkov.');
 };

--- a/src/checkovInstaller.ts
+++ b/src/checkovInstaller.ts
@@ -118,12 +118,12 @@ export interface CheckovInstallation {
 }
 
 export const installOrUpdateCheckov = async (logger: Logger, installationDir: string, checkovVersion: string): Promise<CheckovInstallation> => {
-    // const dockerCheckovPath = await installOrUpdateCheckovWithDocker(logger, checkovVersion);
-    // if (dockerCheckovPath) return { checkovInstallationMethod: 'docker' , checkovPath: dockerCheckovPath };
-    // const pip3CheckovPath = await installOrUpdateCheckovWithPip3(logger, checkovVersion);
-    // if (pip3CheckovPath) return { checkovInstallationMethod: 'pip3' , checkovPath: pip3CheckovPath };
-    // const pipenvCheckovPath = await installOrUpdateCheckovWithPipenv(logger, installationDir, checkovVersion);
-    // if (pipenvCheckovPath) return { checkovInstallationMethod: 'pipenv' , checkovPath: pipenvCheckovPath };
+    const dockerCheckovPath = await installOrUpdateCheckovWithDocker(logger, checkovVersion);
+    if (dockerCheckovPath) return { checkovInstallationMethod: 'docker' , checkovPath: dockerCheckovPath };
+    const pip3CheckovPath = await installOrUpdateCheckovWithPip3(logger, checkovVersion);
+    if (pip3CheckovPath) return { checkovInstallationMethod: 'pip3' , checkovPath: pip3CheckovPath };
+    const pipenvCheckovPath = await installOrUpdateCheckovWithPipenv(logger, installationDir, checkovVersion);
+    if (pipenvCheckovPath) return { checkovInstallationMethod: 'pipenv' , checkovPath: pipenvCheckovPath };
 
     logger.warn('All installation / update methods failed; attempting to fall back to a global checkov installation');
 


### PR DESCRIPTION
# In This PR

- If all install / update options fail, use the `checkov` executable, if available. This makes it easier for customers who need to manually install checkov to get around VPNs, etc to install some other way and then have VSCode pick it up.

## Pictures/videos

- [X] I've reviewed my own code
