### PR TITLE
validate repo URL parsing and fall back to config file

### DIFF
--- a/src/checkovRunner.ts
+++ b/src/checkovRunner.ts
@@ -94,8 +94,9 @@ export const runCheckovScan = (logger: Logger, checkovInstallation: CheckovInsta
         const bcIdParam: string[] = useBcIds ? ['--output-bc-ids'] : [];
         const workingDir = vscode.workspace.rootPath;
         getGitRepoName(logger, vscode.window.activeTextEditor?.document.fileName).then((repoName) => {
-            const checkovArguments: string[] = [...dockerRunParams, ...certificateParams, ...bcIdParam, '-s', '--bc-api-key', token, '--repo-id', 
-                repoName, ...filePathParams, '-o', 'json', ...pipRunParams];
+            const repoIdParams = repoName ? ['--repo-id', repoName] : [];
+            const checkovArguments: string[] = [...dockerRunParams, ...certificateParams, ...bcIdParam, '-s', '--bc-api-key', token, 
+                ...repoIdParams, ...filePathParams, '-o', 'json', ...pipRunParams];
             logger.info('Running checkov:');
             logger.info(`${checkovPath} ${checkovArguments.map(argument => argument === token ? '****' : argument).join(' ')}`);
         


### PR DESCRIPTION
# In This PR

- Updates the repo URL parsing to validate that the repo name will actually be accepted by checkov
- Removes the default repo name, allowing users to specify one from a config file as a fallback to when `git remote -v` parsing fails

Example `git remote -v` output:

```
origin  codecommit::us-west-2://repo_name (fetch)
origin  codecommit::us-west-2://repo_name (push)
```

This would get parsed to `/repo_name` and passed as the repo-id to checkov, which would then fail. Since there is no good "org" value to use, the best option is to just pass nothing for the repo-id and allow the user to specify the value in a config file if they want. Otherwise, it will just use the checkov default (and it's all arbitrary at this point anyways).

## Pictures/videos

- [X] I've reviewed my own code
