### PR TITLE
Don't rescan files that have not changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,10 @@
       {
         "command": "checkov.open-log",
         "title": "Open Checkov Log"
+      },
+      {
+        "command": "checkov.clear-results-cache",
+        "title": "Clear Checkov results cache"
       }
     ],
     "configuration": {

--- a/src/checkov/models.ts
+++ b/src/checkov/models.ts
@@ -1,4 +1,4 @@
-import { BoundedFileCache, FileScanCacheEntry } from '../utils';
+import { BoundedFileCache } from '../utils';
 
 export interface FailedCheckovCheck {
     checkId: string;

--- a/src/checkov/models.ts
+++ b/src/checkov/models.ts
@@ -1,3 +1,5 @@
+import { FileScanCacheEntry } from '../utils';
+
 export interface FailedCheckovCheck {
     checkId: string;
     checkName: string;
@@ -32,4 +34,8 @@ export interface CheckovResponseRaw {
     results: {
         failed_checks: FailedCheckovCheckRaw[];
     };
+}
+
+export interface ResultsCacheObject {
+    [key: string]: FileScanCacheEntry
 }

--- a/src/checkov/models.ts
+++ b/src/checkov/models.ts
@@ -1,4 +1,4 @@
-import { FileScanCacheEntry } from '../utils';
+import { BoundedFileCache, FileScanCacheEntry } from '../utils';
 
 export interface FailedCheckovCheck {
     checkId: string;
@@ -37,5 +37,5 @@ export interface CheckovResponseRaw {
 }
 
 export interface ResultsCacheObject {
-    [key: string]: FileScanCacheEntry
+    [key: string]: BoundedFileCache;
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -5,3 +5,4 @@ export const OPEN_CONFIGURATION_COMMAND = 'checkov.configuration.open';
 export const INSTALL_OR_UPDATE_CHECKOV_COMMAND = 'checkov.install-or-update-checkov';
 export const GET_INSTALLATION_DETAILS_COMMAND = 'checkov.about-checkov';
 export const OPEN_CHECKOV_LOG = 'checkov.open-log';
+export const CLEAR_RESULTS_CACHE = 'checkov.clear-results-cache';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,6 @@ import { initializeStatusBarItem, setErrorStatusBarItem, setPassedStatusBarItem,
 import { assureTokenSet, getCheckovVersion, shouldDisableErrorMessage, getPathToCert, getUseBcIds, getPrismaUrl, getUseDebugLogs } from './configuration';
 import { CLEAR_RESULTS_CACHE, GET_INSTALLATION_DETAILS_COMMAND, INSTALL_OR_UPDATE_CHECKOV_COMMAND, OPEN_CHECKOV_LOG, OPEN_CONFIGURATION_COMMAND, OPEN_EXTERNAL_COMMAND, REMOVE_DIAGNOSTICS_COMMAND, RUN_FILE_SCAN_COMMAND } from './commands';
 import { getConfigFilePath } from './parseCheckovConfig';
-import { clear } from 'console';
 
 export const CHECKOV_MAP = 'checkovMap';
 const logFileName = 'checkov.log';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,8 +8,9 @@ import { fixCodeActionProvider, providedCodeActionKinds } from './suggestFix';
 import { getLogger, saveCheckovResult, isSupportedFileType, extensionVersion, runVersionCommand, getFileHash, saveCachedResults, getCachedResults, clearCache, checkovVersionKey } from './utils';
 import { initializeStatusBarItem, setErrorStatusBarItem, setPassedStatusBarItem, setReadyStatusBarItem, setSyncingStatusBarItem, showAboutCheckovMessage, showContactUsDetails } from './userInterface';
 import { assureTokenSet, getCheckovVersion, shouldDisableErrorMessage, getPathToCert, getUseBcIds, getPrismaUrl, getUseDebugLogs } from './configuration';
-import { GET_INSTALLATION_DETAILS_COMMAND, INSTALL_OR_UPDATE_CHECKOV_COMMAND, OPEN_CHECKOV_LOG, OPEN_CONFIGURATION_COMMAND, OPEN_EXTERNAL_COMMAND, REMOVE_DIAGNOSTICS_COMMAND, RUN_FILE_SCAN_COMMAND } from './commands';
+import { CLEAR_RESULTS_CACHE, GET_INSTALLATION_DETAILS_COMMAND, INSTALL_OR_UPDATE_CHECKOV_COMMAND, OPEN_CHECKOV_LOG, OPEN_CONFIGURATION_COMMAND, OPEN_EXTERNAL_COMMAND, REMOVE_DIAGNOSTICS_COMMAND, RUN_FILE_SCAN_COMMAND } from './commands';
 import { getConfigFilePath } from './parseCheckovConfig';
+import { clear } from 'console';
 
 export const CHECKOV_MAP = 'checkovMap';
 const logFileName = 'checkov.log';
@@ -31,8 +32,6 @@ export function activate(context: vscode.ExtensionContext): void {
         checkovRunCancelTokenSource.dispose();
         checkovRunCancelTokenSource = new vscode.CancellationTokenSource();
     };
-
-    // clearCache(context, logger);
 
     // Set diagnostics collection
     const diagnostics = vscode.languages.createDiagnosticCollection('checkov-alerts');
@@ -96,6 +95,9 @@ export function activate(context: vscode.ExtensionContext): void {
         }),
         vscode.commands.registerCommand(OPEN_CHECKOV_LOG, async () => {
             vscode.window.showTextDocument(vscode.Uri.joinPath(context.logUri, logFileName));
+        }),
+        vscode.commands.registerCommand(CLEAR_RESULTS_CACHE, async () => {
+            clearCache(context, logger);
         })
     );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -158,11 +158,11 @@ export function activate(context: vscode.ExtensionContext): void {
                 const hash = getFileHash(filename);
                 const cachedResults = fileCache.get(hash);
                 if (cachedResults) {
-                    logger.debug(`Found cached results for file ${filename} (hash: ${hash})`);
+                    logger.debug(`Found cached results for hash: ${hash} (cached scan filename ${cachedResults.filename})`);
                     handleScanResults(filename, vscode.window.activeTextEditor, context.workspaceState, cachedResults.results);
                     return;
                 } else {
-                    logger.debug(`useCache is true, but did not find cached results for hash ${hash}`);
+                    logger.debug(`useCache is true, but did not find cached results for hash: ${hash} (filename ${filename})`);
                 }
             }
             await runScan(vscode.window.activeTextEditor, token, certPath, useBcIds, debugLogs, checkovRunCancelTokenSource.token, checkovVersion, prismaUrl, fileUri);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,6 @@
 import * as vscode from 'vscode';
+import * as crypto from 'crypto';
+import * as fs from 'fs';
 import { exec, ExecOptions } from 'child_process';
 import winston from 'winston';
 import { FailedCheckovCheck } from './checkov';
@@ -22,6 +24,11 @@ export const extensionVersion = extensionData ? extensionData.packageJSON.versio
 export const isWindows = process.platform === 'win32';
 
 export type TokenType = 'bc-token' | 'prisma';
+
+export type FileScanCacheEntry = {
+    hash: string,
+    results: FailedCheckovCheck[]
+};
 
 type ExecOutput = [stdout: string, stderr: string];
 export const asyncExec = async (commandToExecute: string, options: ExecOptions = {}): Promise<ExecOutput> => {
@@ -207,4 +214,11 @@ export const getTokenType = (token: string): TokenType => token.includes('::') ?
 export const normalizePath = (filePath: string): string[] => {
     const absPath = path.resolve(filePath);
     return [path.basename(absPath), absPath];
+};
+
+export const getFileHash = (filename: string): string => {
+    const fileBuffer = fs.readFileSync(filename);
+    const hashSum = crypto.createHash('md5');
+    hashSum.update(fileBuffer);
+    return hashSum.digest('hex');
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,6 +27,7 @@ export type TokenType = 'bc-token' | 'prisma';
 
 export type FileScanCacheEntry = {
     hash: string,
+    filename: string,
     results: FailedCheckovCheck[]
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -252,9 +252,10 @@ export const clearCache = (context: vscode.ExtensionContext, logger: Logger): vo
     context.workspaceState.update(cacheDateKey, undefined);
 };
 
-const getDate = (): string => {
+const getDate = (): number => {
     const today = new Date();
-    return `${today.getFullYear()}/${today.getMonth()}/${today.getDate()}`;
+    today.setHours(0, 0, 0, 0);
+    return today.getTime();
 };
 
 const validateCacheExpiration = (context: vscode.ExtensionContext, logger: Logger): void => {


### PR DESCRIPTION
# In This PR

- Adds a file hash-based caching mechanism so skip rescanning files that have not changed since the last scan. By caching purely based on the hash (as opposed to the filename), it also gracefully handle scans that occur on temp (unsaved) files.

## Pictures/videos

- [X] I've reviewed my own code
