### PR TITLE
show severity in output if it exists

### DIFF
--- a/src/checkov/checkovParser.ts
+++ b/src/checkov/checkovParser.ts
@@ -12,7 +12,8 @@ const resultParserSCA = ({ useBcIds = false }: ParserOptions) => (rawCheck: Fail
     fileLineRange: rawCheck.file_line_range,
     resource: rawCheck.resource,
     guideline: rawCheck.guideline || rawCheck.short_description,
-    fixedDefinition: rawCheck.fixed_definition
+    fixedDefinition: rawCheck.fixed_definition,
+    severity: rawCheck.severity
 });
 const resultParserDefault = ({ useBcIds = false }: ParserOptions) => (rawCheck: FailedCheckovCheckRaw): FailedCheckovCheck => ({
     checkId: (useBcIds && rawCheck.bc_check_id) || rawCheck.check_id,
@@ -20,7 +21,8 @@ const resultParserDefault = ({ useBcIds = false }: ParserOptions) => (rawCheck: 
     fileLineRange: rawCheck.file_line_range,
     resource: rawCheck.resource,
     guideline: rawCheck.guideline || rawCheck.description,
-    fixedDefinition: rawCheck.fixed_definition
+    fixedDefinition: rawCheck.fixed_definition,
+    severity: rawCheck.severity
 });
 
 type ParserFunction = (rawCheck: FailedCheckovCheckRaw) => FailedCheckovCheck;

--- a/src/checkov/models.ts
+++ b/src/checkov/models.ts
@@ -5,6 +5,7 @@ export interface FailedCheckovCheck {
     resource: string;
     guideline?: string;
     fixedDefinition?: string;
+    severity?: string;
 }
 
 export interface CheckovResponse {

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { Logger } from 'winston';
 import { FailedCheckovCheck } from './checkov';
 
 export interface DiagnosticReferenceCode {
@@ -18,9 +19,8 @@ export const applyDiagnostics = (document: vscode.TextDocument, diagnostics: vsc
                     target: vscode.Uri.parse(failure.guideline),
                     value: failure.checkId
                 } : `${failure.checkId}${failure.guideline ? `: ${failure.guideline}` : ''}`;
-
         foundDiagnostics.push({
-            message: failure.checkName,
+            message: `${failure.severity ? (failure.severity + ': ') : ''}${failure.checkName}`,
             range: new vscode.Range(startPos, line.range.end),
             severity: vscode.DiagnosticSeverity.Error,
             source: 'Checkov ',

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import { Logger } from 'winston';
 import { FailedCheckovCheck } from './checkov';
 
 export interface DiagnosticReferenceCode {


### PR DESCRIPTION
# In This PR

- Adds severities in the output in front of the check name, if the severity exists (e.g., `MEDIUM: Ensure...`)

## Pictures/videos

- [X] I've reviewed my own code
