### PR TITLE
use plain JS objects for cache

### DIFF
--- a/src/checkov/models.ts
+++ b/src/checkov/models.ts
@@ -1,4 +1,4 @@
-import { BoundedFileCache } from '../utils';
+import { FileScanCacheEntry } from '../utils';
 
 export interface FailedCheckovCheck {
     checkId: string;
@@ -37,6 +37,11 @@ export interface CheckovResponseRaw {
     };
 }
 
-export interface ResultsCacheObject {
-    [key: string]: BoundedFileCache;
+export interface FileCache {
+    oldest: number;
+    elements: FileScanCacheEntry[];
+}
+
+export interface ResultsCache {
+    [key: string]: FileCache;
 }


### PR DESCRIPTION
# In This PR

- Fixes #80 when loading a saved cache after restarting VSCode. The saved object doesn't get deserialized into a BoundedFileCache, so the class methods do not work. This replaces those methods with helper methods and a new interface type. It preserves compatibility with a saved cache.

## Pictures/videos

- [X] I've reviewed my own code
