### PR TITLE
using dockerode to kill containers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -232,12 +232,6 @@
 				}
 			}
 		},
-		"@types/uuid": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.0.tgz",
-			"integrity": "sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==",
-			"dev": true
-		},
 		"@types/vscode": {
 			"version": "1.52.0",
 			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
@@ -2292,11 +2286,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-		},
-		"uuid": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-			"integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
 		},
 		"v8-compile-cache": {
 			"version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,11 @@
 				}
 			}
 		},
+		"@balena/dockerignore": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+			"integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="
+		},
 		"@colors/colors": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -138,6 +143,26 @@
 			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
 			"dev": true
 		},
+		"@types/docker-modem": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.2.tgz",
+			"integrity": "sha512-qC7prjoEYR2QEe6SmCVfB1x3rfcQtUr1n4x89+3e0wSTMQ/KYCyf+/RAA9n2tllkkNc6//JMUZePdFRiGIWfaQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"@types/ssh2": "*"
+			}
+		},
+		"@types/dockerode": {
+			"version": "3.3.14",
+			"resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.14.tgz",
+			"integrity": "sha512-PUTwtySPzCbjZ/uqRMBWKHtLGqBAlhnLitzHuom19NEX0KBYsQXqbVlig+zbUgYQU1paDeQURXj7QNglh1RI6A==",
+			"dev": true,
+			"requires": {
+				"@types/docker-modem": "*",
+				"@types/node": "*"
+			}
+		},
 		"@types/glob": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -188,6 +213,29 @@
 			"version": "7.3.10",
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.10.tgz",
 			"integrity": "sha512-zsv3fsC7S84NN6nPK06u79oWgrPVd0NvOyqgghV1haPaFcVxIrP4DLomRwGAXk0ui4HZA7mOcSFL98sMVW9viw==",
+			"dev": true
+		},
+		"@types/ssh2": {
+			"version": "1.11.7",
+			"resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.11.7.tgz",
+			"integrity": "sha512-MaVSlZOiekRUHnxL2NAmDkcU3+bTwz+ZRktLygjQCnxhLjDzN+XnsG6JUdoocmfxatMiqFo/6eb48uVqFaxBsg==",
+			"dev": true,
+			"requires": {
+				"@types/node": "^18.11.18"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "18.11.18",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+					"integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
+					"dev": true
+				}
+			}
+		},
+		"@types/uuid": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.0.tgz",
+			"integrity": "sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==",
 			"dev": true
 		},
 		"@types/vscode": {
@@ -364,6 +412,14 @@
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 			"dev": true
 		},
+		"asn1": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+			"integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+			"requires": {
+				"safer-buffer": "~2.1.0"
+			}
+		},
 		"astral-regex": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -395,6 +451,19 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
+		"base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+			"requires": {
+				"tweetnacl": "^0.14.3"
+			}
+		},
 		"big-integer": {
 			"version": "1.6.51",
 			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
@@ -416,6 +485,28 @@
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
 			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
 			"dev": true
+		},
+		"bl": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+			"requires": {
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
 		},
 		"bluebird": {
 			"version": "3.4.7",
@@ -448,6 +539,15 @@
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
 		},
+		"buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"requires": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
+			}
+		},
 		"buffer-indexof-polyfill": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
@@ -459,6 +559,12 @@
 			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
 			"integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
 			"dev": true
+		},
+		"buildcheck": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.3.tgz",
+			"integrity": "sha512-pziaA+p/wdVImfcbsZLNF32EiWyujlQLwolMqUQE8xpKNOH7KmZQaY8sXN7DGOEzPAElo9QTaeNRfGnf3iOJbA==",
+			"optional": true
 		},
 		"callsites": {
 			"version": "3.1.0",
@@ -548,6 +654,11 @@
 				"readdirp": "~3.5.0"
 			}
 		},
+		"chownr": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+		},
 		"cliui": {
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -619,6 +730,16 @@
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
 			"dev": true
 		},
+		"cpu-features": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.4.tgz",
+			"integrity": "sha512-fKiZ/zp1mUwQbnzb9IghXtHtDoTMtNeb8oYGx6kX2SYfhnG0HNdBEBIzB9b5KlXu5DQPhfy3mInbBxFcgwAr3A==",
+			"optional": true,
+			"requires": {
+				"buildcheck": "0.0.3",
+				"nan": "^2.15.0"
+			}
+		},
 		"cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -634,7 +755,6 @@
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
 			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
 			"requires": {
 				"ms": "2.1.2"
 			}
@@ -671,6 +791,39 @@
 				"path-type": "^4.0.0"
 			}
 		},
+		"docker-modem": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-3.0.6.tgz",
+			"integrity": "sha512-h0Ow21gclbYsZ3mkHDfsYNDqtRhXS8fXr51bU0qr1dxgTMJj0XufbzX+jhNOvA8KuEEzn6JbvLVhXyv+fny9Uw==",
+			"requires": {
+				"debug": "^4.1.1",
+				"readable-stream": "^3.5.0",
+				"split-ca": "^1.0.1",
+				"ssh2": "^1.11.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
+		"dockerode": {
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.4.tgz",
+			"integrity": "sha512-3EUwuXnCU+RUlQEheDjmBE0B7q66PV9Rw5NiH1sXwINq0M9c5ERP9fxgkw36ZHOtzf4AGEEYySnkx/sACC9EgQ==",
+			"requires": {
+				"@balena/dockerignore": "^1.0.2",
+				"docker-modem": "^3.0.0",
+				"tar-fs": "~2.0.1"
+			}
+		},
 		"doctrine": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -699,6 +852,14 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
 			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+		},
+		"end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"requires": {
+				"once": "^1.4.0"
+			}
 		},
 		"enquirer": {
 			"version": "2.3.6",
@@ -1005,6 +1166,11 @@
 				"mime-types": "^2.1.12"
 			}
 		},
+		"fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1143,6 +1309,11 @@
 				"agent-base": "6",
 				"debug": "4"
 			}
+		},
+		"ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
 		},
 		"ignore": {
 			"version": "5.2.0",
@@ -1402,6 +1573,11 @@
 				"minimist": "^1.2.6"
 			}
 		},
+		"mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+		},
 		"mocha": {
 			"version": "8.4.0",
 			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz",
@@ -1524,6 +1700,12 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
+		"nan": {
+			"version": "2.17.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+			"integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+			"optional": true
+		},
 		"nanoid": {
 			"version": "3.1.20",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
@@ -1546,7 +1728,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -1647,6 +1828,15 @@
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
+		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
 		},
 		"punycode": {
 			"version": "2.1.1",
@@ -1760,6 +1950,11 @@
 			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
 			"integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
 		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
 		"semver": {
 			"version": "7.3.7",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
@@ -1849,11 +2044,27 @@
 				}
 			}
 		},
+		"split-ca": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+			"integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ=="
+		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
+		},
+		"ssh2": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.11.0.tgz",
+			"integrity": "sha512-nfg0wZWGSsfUe/IBJkXVll3PEZ//YH2guww+mP88gTpuSU4FtZN7zu9JoeTGOyCNx2dTDtT9fOpWwlzyj4uOOw==",
+			"requires": {
+				"asn1": "^0.2.4",
+				"bcrypt-pbkdf": "^1.0.2",
+				"cpu-features": "~0.0.4",
+				"nan": "^2.16.0"
+			}
 		},
 		"stack-trace": {
 			"version": "0.0.10",
@@ -1943,6 +2154,41 @@
 				}
 			}
 		},
+		"tar-fs": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
+			"integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
+			"requires": {
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.0.0"
+			}
+		},
+		"tar-stream": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"requires": {
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
 		"text-hex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -1988,6 +2234,11 @@
 			"requires": {
 				"tslib": "^1.8.1"
 			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
 		},
 		"type-check": {
 			"version": "0.4.0",
@@ -2041,6 +2292,11 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"uuid": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+			"integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
 		},
 		"v8-compile-cache": {
 			"version": "2.3.0",
@@ -2214,8 +2470,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"y18n": {
 			"version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
     "@types/mocha": "^8.2.3",
     "@types/node": "^12.20.55",
     "@types/semver": "^7.3.10",
-    "@types/uuid": "^9.0.0",
     "@types/vscode": "1.52.0",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
@@ -141,7 +140,6 @@
     "dockerode": "^3.3.4",
     "lodash": "^4.17.21",
     "semver": "^7.3.7",
-    "uuid": "^9.0.0",
     "winston": "^3.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -119,12 +119,14 @@
     "test": "node ./out/test/runTest.js"
   },
   "devDependencies": {
+    "@types/dockerode": "^3.3.14",
     "@types/glob": "^7.2.0",
     "@types/js-yaml": "^4.0.5",
     "@types/lodash": "^4.14.182",
     "@types/mocha": "^8.2.3",
     "@types/node": "^12.20.55",
     "@types/semver": "^7.3.10",
+    "@types/uuid": "^9.0.0",
     "@types/vscode": "1.52.0",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
@@ -136,8 +138,10 @@
   },
   "dependencies": {
     "axios": "^0.27.2",
+    "dockerode": "^3.3.4",
     "lodash": "^4.17.21",
     "semver": "^7.3.7",
+    "uuid": "^9.0.0",
     "winston": "^3.7.2"
   }
 }

--- a/src/checkov/checkovRunner.ts
+++ b/src/checkov/checkovRunner.ts
@@ -2,10 +2,14 @@ import * as vscode from 'vscode';
 import { spawn } from 'child_process';
 import * as path from 'path';
 import { Logger } from 'winston';
+import { v4 as uuidv4 } from 'uuid';
+import Docker from 'dockerode';
 import { CheckovInstallation } from './checkovInstaller';
 import { convertToUnixPath, getGitRepoName, getDockerPathParams, runVersionCommand, normalizePath } from '../utils';
 import { CheckovResponse, CheckovResponseRaw } from './models';
 import { parseCheckovResponse } from './checkovParser';
+
+const docker = new Docker();
 
 const dockerMountDir = '/checkovScan';
 const configMountDir = '/checkovConfig';
@@ -30,7 +34,7 @@ const getPathParamsForDockerRun = (mountDir: string, filePath: string | undefine
     return [dockerParams, checkovParams];
 };
 
-const getDockerRunParams = (workspaceRoot: string | undefined, filePath: string, extensionVersion: string, configFilePath: string | undefined, checkovVersion: string | undefined, prismaUrl: string | undefined, externalChecksDir: string |undefined, certPath: string | undefined, debugLogs: boolean | undefined) => {
+const getDockerRunParams = (workspaceRoot: string | undefined, filePath: string, extensionVersion: string, configFilePath: string | undefined, checkovVersion: string | undefined, prismaUrl: string | undefined, externalChecksDir: string |undefined, certPath: string | undefined, debugLogs: boolean | undefined, uniqueName: string) => {
     const image = `bridgecrew/checkov:${checkovVersion}`;
     const pathParams = getDockerPathParams(workspaceRoot, filePath);
     // if filepath is within the workspace, then the mount root will be the workspace path, and the file path will be the relative file path from there.
@@ -39,12 +43,13 @@ const getDockerRunParams = (workspaceRoot: string | undefined, filePath: string,
     const filePathToScan = convertToUnixPath(pathParams[0] ? pathParams[1] : path.basename(filePath));
     const prismaUrlParams = prismaUrl ? ['--env', `PRISMA_API_URL=${prismaUrl}`] : [];
     const debugLogParams = debugLogs ? ['--env', 'LOG_LEVEL=DEBUG'] : [];
+    const nameParam = `--name ${uniqueName}`;
 
     const [caCertDockerParams, caCertCheckovParams] = getPathParamsForDockerRun(caMountDir, certPath, '--ca-certificate');
     const [configFileDockerParams, configFileCheckovParams] = getPathParamsForDockerRun(configMountDir, configFilePath, '--config-file');
     const [externalChecksDockerParams, externalChecksCheckovParams] = getPathParamsForDockerRun(externalChecksMountDir, externalChecksDir, '--external-checks-dir');
     
-    const dockerParams = ['run', '--rm', '--tty', ...prismaUrlParams, ...debugLogParams, '--env', 'BC_SOURCE=vscode', '--env', `BC_SOURCE_VERSION=${extensionVersion}`,
+    const dockerParams = ['run', '--rm', '--tty', nameParam, ...prismaUrlParams, ...debugLogParams, '--env', 'BC_SOURCE=vscode', '--env', `BC_SOURCE_VERSION=${extensionVersion}`,
         '-v', `"${mountRoot}:${dockerMountDir}"`, ...caCertDockerParams, ...configFileDockerParams, ...externalChecksDockerParams, '-w', dockerMountDir];
     
     return [...dockerParams, image, ...configFileCheckovParams, ...caCertCheckovParams, ...externalChecksCheckovParams, '-f', filePathToScan];
@@ -60,7 +65,9 @@ export const runCheckovScan = (logger: Logger, checkovInstallation: CheckovInsta
     certPath: string | undefined, useBcIds: boolean | undefined, debugLogs: boolean | undefined, cancelToken: vscode.CancellationToken, configPath: string | undefined, checkovVersion: string,  prismaUrl: string | undefined, externalChecksDir: string | undefined): Promise<CheckovResponse> => {
     return new Promise((resolve, reject) => {   
         const { checkovInstallationMethod, checkovPath } = checkovInstallation;
-        const dockerRunParams = checkovInstallationMethod === 'docker' ? getDockerRunParams(vscode.workspace.rootPath, fileName, extensionVersion, configPath, checkovInstallation.version, prismaUrl, externalChecksDir, certPath, debugLogs) : [];
+        const uuid = uuidv4();
+        const uniqueRunName = `vscode-checkov-${uuid}`;
+        const dockerRunParams = checkovInstallationMethod === 'docker' ? getDockerRunParams(vscode.workspace.rootPath, fileName, extensionVersion, configPath, checkovInstallation.version, prismaUrl, externalChecksDir, certPath, debugLogs, uniqueRunName) : [];
         const pipRunParams =  ['pipenv', 'pip3'].includes(checkovInstallationMethod) ? getpipRunParams(configPath) : [];
         const filePathParams = checkovInstallationMethod === 'docker' ? [] : ['-f', `"${fileName}"`];
         const certificateParams: string[] = certPath && checkovInstallationMethod !== 'docker' ? ['-ca', `"${certPath}"`] : [];
@@ -74,11 +81,8 @@ export const runCheckovScan = (logger: Logger, checkovInstallation: CheckovInsta
                 ...repoIdParams, ...filePathParams, ...skipCheckParam, '-o', 'json', ...pipRunParams, ...externalChecksParams];
             logger.info('Running checkov:');
             logger.info(`${checkovPath} ${checkovArguments.map(argument => argument === token ? '****' : argument).join(' ')}`);
-        
-            runVersionCommand(logger, checkovPath, checkovVersion);
 
             const debugLogEnv = debugLogs ? { LOG_LEVEL: 'DEBUG' } : {};
-        
             const ckv = spawn(checkovPath, checkovArguments,
                 {
                     shell: true,
@@ -134,8 +138,9 @@ export const runCheckovScan = (logger: Logger, checkovInstallation: CheckovInsta
             });
 
             cancelToken.onCancellationRequested((cancelEvent) => {
-                ckv.kill('SIGABRT');
-                logger.info('Cancellation token invoked, aborting checkov run.', { cancelEvent });
+                const container = docker.getContainer(uniqueRunName);
+                container.kill();
+                logger.info('Cancellation token invoked, aborting checkov run.', { uniqueRunName, cancelEvent });
             });
         });
     });


### PR DESCRIPTION
# In This PR

When running on M1 processors (maybe on more archs), some checkov containers are not killed when `onCancellationRequested` event is fired. the reason is some percentage of them are throwing the following error: 
`qemu: uncaught target signal 6 (Aborted) - core dumped`. This is due to this bug - https://github.com/docker/for-mac/issues/6264
Now that we started scanning all file types this has become a big issue, because docker processes grew significantly.

In this PR I replaced the `child_proccess.kill` method with `docerode` kill method which works much better. I also attach a unique identifier for each run to be passed to the `kill` command.
In addition, removing the `runVersionCommand` on each run, which setup a container from scratch on each run for no reason, overloading the docker agent.

## Pictures/videos

- [x] I've reviewed my own code
