### PR TITLE
change badge to png

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Maintained by Bridgecrew.io](https://img.shields.io/badge/maintained%20by-bridgecrew.io-blueviolet)](https://bridgecrew.io/?utm_source=github&utm_medium=organic_oss&utm_campaign=checkov-vscode)
 [![build status](https://github.com/bridgecrewio/checkov-vscode/workflows/build/badge.svg)](https://github.com/bridgecrewio/checkov-vscode/actions?query=workflow%3Abuild)
-[![Installs-count](https://vsmarketplacebadges.dev/installs-short/Bridgecrew.checkov.svg)](https://marketplace.visualstudio.com/items?itemName=Bridgecrew.checkov)
+[![Installs-count](https://vsmarketplacebadges.dev/installs-short/Bridgecrew.checkov.png)](https://marketplace.visualstudio.com/items?itemName=Bridgecrew.checkov)
 [![slack-community](https://img.shields.io/badge/Slack-contact%20us-lightgrey.svg?logo=slack)](https://slack.bridgecrew.io/?utm_source=github&utm_medium=organic_oss&utm_campaign=checkov-vscode)
 
 # Checkov Extension for Visual Studio Code


### PR DESCRIPTION
# In This PR

Change badge from svg to png due to following error in publish: `SVGs are restricted in README.md; please use other file image formats, such as PNG: https://vsmarketplacebadges.dev/installs-short/Bridgecrew.checkov.svg`

## Pictures/videos

- [ ] I've reviewed my own code
