### PR TITLE
skip scanning of log files

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,7 +33,7 @@ export const checkovVersionApi = 'api/v1/checkovVersion';
 
 const maxCacheSizePerFile = 10;
 
-const unsupportedExtensions: string[] = [];
+const unsupportedExtensions: string[] = ['.log'];
 const unsupportedFileNames: string[] = [];
 
 export type TokenType = 'bc-token' | 'prisma';


### PR DESCRIPTION
# In This PR
- Entring a log file (checkov.log for example) triggered a lot of scans that where canceled and recreated on writing.
This PR Add `.log` files to the unsupported ext to prevent that.