### PR TITLE
Adding Framework/Skip-Framework functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "checkov",
-	"version": "1.0.96",
+	"version": "1.0.97",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -113,12 +113,12 @@
         },
         "checkov.skipFrameworks": {
           "title": "Skip Frameworks",
-          "markdownDescription": "Filter scan to skip specific frameworks (e.g., 'arm json secrets serverless').  \n Add multiple frameworks using spaces.  \n See [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.",
+          "markdownDescription": "Filter scan to skip specific frameworks (e.g., 'arm json secrets serverless').  \n Add multiple frameworks using spaces.  \n See [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.\nYou may need to run the extension command 'Clear Checkov results cache' after modifying this setting.",
           "type": "string"
         },
         "checkov.frameworks": {
           "title": "Frameworks",
-          "markdownDescription": "Filter scan to run only on specific frameworks (e.g., 'arm json secrets serverless').  \n Add multiple frameworks using spaces.  \n See [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.",
+          "markdownDescription": "Filter scan to run only on specific frameworks (e.g., 'arm json secrets serverless').  \n Add multiple frameworks using spaces.  \n See [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.\nYou may need to run the extension command 'Clear Checkov results cache' after modifying this setting.",
           "type": "string"
         }
       }

--- a/package.json
+++ b/package.json
@@ -113,12 +113,12 @@
         },
         "checkov.skipFrameworks": {
           "title": "Skip Frameworks",
-          "markdownDescription": "Comma-separated list of frameworks to skip (e.g., 'arm, json, secrets, serverless'). \n This is useful if you do not need to scan or do not have the required license for a specific framework. \n See [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.",
+          "markdownDescription": "Filter scan to skip specific frameworks (e.g., 'arm json secrets serverless').  \n Add multiple frameworks using spaces.  \n See [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.",
           "type": "string"
         },
         "checkov.frameworks": {
           "title": "Frameworks",
-          "markdownDescription": "Comma-separated list of frameworks to scan (e.g., 'arm, json, secrets, serverless'). \n This is useful if you only want to scan specific frameworks. \n See [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.",
+          "markdownDescription": "Filter scan to run only on specific frameworks (e.g., 'arm json secrets serverless').  \n Add multiple frameworks using spaces.  \n See [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.",
           "type": "string"
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkov",
-  "version": "1.0.96",
+  "version": "1.0.97",
   "displayName": "Checkov",
   "publisher": "Bridgecrew",
   "description": "Find and fix misconfigurations in infrastructure-as-code manifests like Terraform, Kubernetes, Cloudformation, Serverless framework, Arm templates using Checkov - static analysis for infrastructure as code .",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkov",
-  "version": "1.0.97",
+  "version": "1.0.96",
   "displayName": "Checkov",
   "publisher": "Bridgecrew",
   "description": "Find and fix misconfigurations in infrastructure-as-code manifests like Terraform, Kubernetes, Cloudformation, Serverless framework, Arm templates using Checkov - static analysis for infrastructure as code .",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,16 @@
           "title": "Skip SSL cert verification",
           "markdownDescription": "Skip SSL certificate verification. Use this to bypass errors related to SSL certificates. Warning: this should only be used for testing purposes. Skipping certificate verification is dangerous as invalid and falsified certificates cannot be detected.",
           "type": "boolean"
+        },
+        "checkov.skipFrameworks": {
+          "title": "Skip Frameworks",
+          "markdownDescription": "Comma-separated list of frameworks to skip (e.g., 'arm, json, secrets, serverless'). \n This is useful if you do not need to scan or do not have the required license for a specific framework. \n See [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.",
+          "type": "string"
+        },
+        "checkov.frameworks": {
+          "title": "Frameworks",
+          "markdownDescription": "Comma-separated list of frameworks to scan (e.g., 'arm, json, secrets, serverless'). \n This is useful if you only want to scan specific frameworks. \n See [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.",
+          "type": "string"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -113,12 +113,12 @@
         },
         "checkov.skipFrameworks": {
           "title": "Skip Frameworks",
-          "markdownDescription": "Filter scan to skip specific frameworks (e.g., 'arm json secrets serverless').  \n Add multiple frameworks using spaces.  \n See [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.\nYou may need to run the extension command 'Clear Checkov results cache' after modifying this setting.",
+          "markdownDescription": "Filter scan to skip specific frameworks (e.g., 'arm json secrets serverless').  \n Add multiple frameworks using spaces.  \n See [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.  \n You may need to run the extension command 'Clear Checkov results cache' after modifying this setting.",
           "type": "string"
         },
         "checkov.frameworks": {
           "title": "Frameworks",
-          "markdownDescription": "Filter scan to run only on specific frameworks (e.g., 'arm json secrets serverless').  \n Add multiple frameworks using spaces.  \n See [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.\nYou may need to run the extension command 'Clear Checkov results cache' after modifying this setting.",
+          "markdownDescription": "Filter scan to run only on specific frameworks (e.g., 'arm json secrets serverless').  \n Add multiple frameworks using spaces.  \n See [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.  \n You may need to run the extension command 'Clear Checkov results cache' after modifying this setting.",
           "type": "string"
         }
       }

--- a/src/checkov/checkovRunner.ts
+++ b/src/checkov/checkovRunner.ts
@@ -75,8 +75,8 @@ export const runCheckovScan = (logger: Logger, checkovInstallation: CheckovInsta
         const noCertVerifyParam: string[] = noCertVerify ? ['--no-cert-verify'] : [];
         const skipCheckParam: string[] = skipChecks.length ? ['--skip-check', skipChecks.join(',')] : [];
         const externalChecksParams: string[] = externalChecksDir && checkovInstallationMethod !== 'docker' ? ['--external-checks-dir', externalChecksDir] : [];
-        const frameworkParams: string[] = frameworks ? ['--framework', frameworks.join(' ')] : [];
-        const skipFrameworkParams: string[] = skipFrameworks ? ['--skip-framework', skipFrameworks.join(' ')] : [];
+        const frameworkParams: string[] = frameworks ? frameworks.reduce((acc, framework) => [...acc, '--framework', framework], [] as string[] ) : [];
+        const skipFrameworkParams: string[] = skipFrameworks ? skipFrameworks.reduce((acc, framework) => [ ...acc, '--skip-framework', framework ], [] as string[] ) : [];
         const workingDir = vscode.workspace.rootPath;
         getGitRepoName(logger, vscode.window.activeTextEditor?.document.fileName).then((repoName) => {
             const repoIdParams = repoName ? ['--repo-id', repoName] : [];

--- a/src/checkov/checkovRunner.ts
+++ b/src/checkov/checkovRunner.ts
@@ -75,8 +75,8 @@ export const runCheckovScan = (logger: Logger, checkovInstallation: CheckovInsta
         const noCertVerifyParam: string[] = noCertVerify ? ['--no-cert-verify'] : [];
         const skipCheckParam: string[] = skipChecks.length ? ['--skip-check', skipChecks.join(',')] : [];
         const externalChecksParams: string[] = externalChecksDir && checkovInstallationMethod !== 'docker' ? ['--external-checks-dir', externalChecksDir] : [];
-        const frameworkParams: string[] = frameworks ? frameworks.reduce((acc, framework) => [...acc, '--framework', framework], [] as string[] ) : [];
-        const skipFrameworkParams: string[] = skipFrameworks ? skipFrameworks.reduce((acc, framework) => [ ...acc, '--skip-framework', framework ], [] as string[] ) : [];
+        const frameworkParams: string[] = frameworks ? ['--framework', frameworks.join(' ')] : [];
+        const skipFrameworkParams: string[] = skipFrameworks ? ['--skip-framework', skipFrameworks.join(' ')] : [];
         const workingDir = vscode.workspace.rootPath;
         getGitRepoName(logger, vscode.window.activeTextEditor?.document.fileName).then((repoName) => {
             const repoIdParams = repoName ? ['--repo-id', repoName] : [];

--- a/src/checkov/checkovRunner.ts
+++ b/src/checkov/checkovRunner.ts
@@ -62,7 +62,7 @@ const cleanupStdout = (stdout: string) => stdout.replace(/.\[0m/g,''); // Clean 
 
 export const runCheckovScan = (logger: Logger, checkovInstallation: CheckovInstallation, extensionVersion: string, fileName: string, token: string, 
     certPath: string | undefined, useBcIds: boolean | undefined, debugLogs: boolean | undefined, noCertVerify: boolean | undefined, cancelToken: vscode.CancellationToken, 
-    configPath: string | undefined, checkovVersion: string,  prismaUrl: string | undefined, externalChecksDir: string | undefined): Promise<CheckovResponse> => {
+    configPath: string | undefined, checkovVersion: string,  prismaUrl: string | undefined, externalChecksDir: string | undefined, skipFrameworks: string[] | undefined, frameworks: string[] | undefined): Promise<CheckovResponse> => {
     return new Promise((resolve, reject) => {   
         const { checkovInstallationMethod, checkovPath } = checkovInstallation;
         const timestamp = Date.now();
@@ -75,11 +75,13 @@ export const runCheckovScan = (logger: Logger, checkovInstallation: CheckovInsta
         const noCertVerifyParam: string[] = noCertVerify ? ['--no-cert-verify'] : [];
         const skipCheckParam: string[] = skipChecks.length ? ['--skip-check', skipChecks.join(',')] : [];
         const externalChecksParams: string[] = externalChecksDir && checkovInstallationMethod !== 'docker' ? ['--external-checks-dir', externalChecksDir] : [];
+        const frameworkParams: string[] = frameworks ? ['--framework', frameworks.join(' ')] : [];
+        const skipFrameworkParams: string[] = skipFrameworks ? ['--skip-framework', skipFrameworks.join(' ')] : [];
         const workingDir = vscode.workspace.rootPath;
         getGitRepoName(logger, vscode.window.activeTextEditor?.document.fileName).then((repoName) => {
             const repoIdParams = repoName ? ['--repo-id', repoName] : [];
             const checkovArguments: string[] = [...dockerRunParams, ...certificateParams, ...bcIdParam, ...noCertVerifyParam, '-s', '--bc-api-key', token, 
-                ...repoIdParams, ...filePathParams, ...skipCheckParam, '-o', 'json', ...pipRunParams, ...externalChecksParams];
+                ...repoIdParams, ...filePathParams, ...skipCheckParam, '-o', 'json', ...pipRunParams, ...externalChecksParams, ...frameworkParams, ...skipFrameworkParams];
             logger.info('Running checkov:');
             logger.info(`${checkovPath} ${checkovArguments.map(argument => argument === token ? '****' : argument).join(' ')}`);
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -55,13 +55,13 @@ export const getNoCertVerify = (): boolean | undefined => {
 export const getSkipFrameworks = (): string[] | undefined => {
     const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov');
     const skipFrameworks = configuration.get<string>('skipFrameworks');
-    return skipFrameworks ? skipFrameworks.split(',').map(entry => entry.trim()) : undefined;
+    return skipFrameworks ? skipFrameworks.split(' ').map(entry => entry.trim()) : undefined;
 };
 
 export const getFrameworks = (): string[] | undefined => {
     const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov');
     const frameworks = configuration.get<string>('frameworks');
-    return frameworks ? frameworks.split(',').map(entry => entry.trim()) : undefined;
+    return frameworks ? frameworks.split(' ').map(entry => entry.trim()) : undefined;
 };
 
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -52,6 +52,18 @@ export const getNoCertVerify = (): boolean | undefined => {
     return noCertVerify;
 };
 
+export const getSkipFrameworks = (): string[] | undefined => {
+    const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov');
+    const skipFrameworks = configuration.get<string>('skipFrameworks');
+    return skipFrameworks ? skipFrameworks.split(',') : undefined;
+};
+
+export const getFrameworks = (): string[] | undefined => {
+    const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov');
+    const frameworks = configuration.get<string>('frameworks');
+    return frameworks ? frameworks.split(',') : undefined;
+};
+
 export const getCheckovVersion = async (logger: Logger): Promise<string> => {
 
     const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov');

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -55,14 +55,15 @@ export const getNoCertVerify = (): boolean | undefined => {
 export const getSkipFrameworks = (): string[] | undefined => {
     const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov');
     const skipFrameworks = configuration.get<string>('skipFrameworks');
-    return skipFrameworks ? skipFrameworks.split(',') : undefined;
+    return skipFrameworks ? skipFrameworks.split(',').map(entry => entry.trim()) : undefined;
 };
 
 export const getFrameworks = (): string[] | undefined => {
     const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov');
     const frameworks = configuration.get<string>('frameworks');
-    return frameworks ? frameworks.split(',') : undefined;
+    return frameworks ? frameworks.split(',').map(entry => entry.trim()) : undefined;
 };
+
 
 export const getCheckovVersion = async (logger: Logger): Promise<string> => {
 


### PR DESCRIPTION
# In This PR

- Added setting "Skip Frameworks" to take a space separated list of frameworks to skip during scanning
  - This results in the `checkov` cli command being appended with `--skip-framework <list of frameworks>` 
- Added setting "Framworks" to take a space separated list of frameworks to use during scanning
  - This results in the `checkov` cli command being appended with `--framework <list of frameworks>` 

## Pictures/videos

#### Skip Frameworks 
![skip-framework](https://github.com/bridgecrewio/checkov-vscode/assets/3013565/18995f07-a58f-4a9d-948e-83e031a71cc9)

#### Frameworks 
![framework](https://github.com/bridgecrewio/checkov-vscode/assets/3013565/3d16d565-3b01-4ce0-865f-913ad36834d1)

## Usage:

```bash
[info]: Starting to scan. 
[debug]: Output: 
[info]: repo urlgit@github.com:mapbox/security-breakglass.git 
[info]: repo namemapbox/security-breakglass 
[info]: Running checkov: 
[info]: checkov --output-bc-ids -s --bc-api-key **** --repo-id mapbox/security-breakglass -f "/Users/billybryant/github/mapbox/security-breakglass/.github/workflows/bandit.yml" --skip-check BC_LIC* -o json --framework arm json github_actions cloudformation --skip-framework sca_package secrets sca_image 
[debug]: Checkov scan process exited with code 0 

... SCAN RESULTS ...
```

- [x] I've reviewed my own code

fixes #135 
